### PR TITLE
feat(search): HF proxy for embeddings, flexible manifests, multi-field embedding text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 sample.doc.json
 *.DS_Store
-
+data/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/package-lock.json
+++ b/package-lock.json
@@ -3467,7 +3467,7 @@
     },
     "packages/ai4data/search": {
       "name": "@ai4data/search",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3467,7 +3467,7 @@
     },
     "packages/ai4data/search": {
       "name": "@ai4data/search",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",

--- a/packages/ai4data/search/README.md
+++ b/packages/ai4data/search/README.md
@@ -56,6 +56,37 @@ client.on('results', ({ data }) => console.log(data))
 
 `workerUrl` defaults to unpkg for the **current package version** (injected at build time), so you usually don't need to pass it. To pin a different version, pass `workerUrl: 'https://unpkg.com/@ai4data/search@0.1.0/dist/worker.mjs'`. If you pass an esm.sh worker URL, the client fetches the raw bundle from unpkg (esm.sh returns a wrapper that fails from a blob). This works from any static host with no build step.
 
+### CSP and Hugging Face (embedding proxy)
+
+The search worker loads the embedding model with **`@xenova/transformers`**, which fetches ONNX and tokenizer files from the Hugging Face Hub by default (`https://huggingface.co/...`). If your page’s **Content Security Policy** blocks `connect-src` to `huggingface.co` or to LFS/CDN hosts, those requests will fail.
+
+**Recommended approach:** serve a **same-origin reverse proxy** that forwards to the Hub, and point Transformers.js at it via **`env.remoteHost`**. This package exposes that as **`transformersRemoteHost`** (and optionally **`transformersRemotePathTemplate`** if your proxy does not mirror the Hub path layout).
+
+- **`modelId`** stays a **full Hub repo id** (e.g. `avsolatorio/GIST-small-Embedding-v0`). It is **not** a raw directory URL; the library builds paths like `…/{model}/resolve/{revision}/tokenizer.json`.
+- Pass an **absolute** base URL (or a path relative to the page, which `SearchClient` resolves against `location.href` so blob workers still target your app origin):
+
+```ts
+const origin = typeof location !== 'undefined' ? location.origin : 'https://example.com'
+
+const client = new SearchClient(manifestUrl, {
+  transformersRemoteHost: `${origin}/api/hf-proxy/`,
+})
+
+await SearchClient.fromCDN(manifestUrl, {
+  workerUrl: `${origin}/dist/worker.mjs`,
+  transformersRemoteHost: `${origin}/api/hf-proxy/`,
+})
+```
+
+Your proxy should forward to the Hub with the **same path suffix** after the prefix, for example:
+
+`GET https://your.app/api/hf-proxy/avsolatorio/GIST-small-Embedding-v0/resolve/main/config.json`  
+→ `GET https://huggingface.co/avsolatorio/GIST-small-Embedding-v0/resolve/main/config.json`
+
+**Important:** Hub responses often **302** to `cdn-lfs.huggingface.co`. The proxy must **follow redirects on the server** and return the final 200 response to the browser; if you pass 302 through, the browser will leave your origin and hit CSP again. The demo server below does this with `fetch(..., { redirect: 'follow' })`.
+
+A second path shape (`/api/resolve-cache/models/<org>/<model>/<revision>/<file…>`) is supported by the same demo server for tools that emit that URL pattern; it maps to `https://huggingface.co/<org>/<model>/resolve/<revision>/<file…>`.
+
 ### Disable BM25 (semantic-only)
 
 To skip loading and building the BM25 index even when the manifest includes `bm25_corpus` (e.g. to save memory or avoid lexical search):
@@ -121,12 +152,13 @@ Host the resulting output directory on any static host (or object storage with C
 
 ## Demo
 
-Two demos are included:
+Demos are included under **`demo/`**:
 
-1. **Local build** (uses the built package from `dist/`): run `npm run demo`, then open **http://localhost:5173/demo/**.
-2. **Standalone HTML** (loads the package from npm via [esm.sh](https://esm.sh)): open **demo/standalone.html** in a browser. Serve the file over HTTP (e.g. from the package directory run `npx serve .` and open http://localhost:3000/demo/standalone.html). No build step; you must use **workerFactory** so the worker is loaded from the CDN (see the file for the pattern).
+1. **Static server** (local `dist/`): run **`npm run demo`**, then open **http://localhost:5173/demo/** (uses [serve](https://www.npmjs.com/package/serve)).
+2. **Standalone HTML** (loads the package from npm via [esm.sh](https://esm.sh)): open **demo/standalone.html** in a browser. Serve the file over HTTP (e.g. `npx serve .` from this package). No build step; the file uses **`SearchClient.fromCDN`** with a worker URL (see the file).
+3. **HF proxy + CSP-friendly demo**: run **`npm run demo:proxy`** from this package (builds, then starts **demo/proxy-server.mjs**). Open **http://localhost:5173/** — it serves **demo/hf-proxy-demo.html**, which sets **`transformersRemoteHost`** to the same-origin **`/api/hf-proxy/`** prefix. The proxy forwards to `huggingface.co` and **follows redirects server-side** so the browser only talks to localhost.
 
-Both demos need a **manifest URL** that points to a `manifest.json` for a search collection (produce one with the pipeline above, or use an existing hosted collection).
+All demos need a **manifest URL** pointing at a hosted **`manifest.json`** (from the Python pipeline above or an existing collection).
 
 ## Development
 

--- a/packages/ai4data/search/demo/hf-proxy-demo.html
+++ b/packages/ai4data/search/demo/hf-proxy-demo.html
@@ -1,0 +1,221 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@ai4data/search — HF proxy demo</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 42rem;
+        margin: 0 auto;
+        padding: 1.5rem;
+      }
+      label {
+        display: block;
+        margin-top: 1rem;
+        font-weight: 600;
+      }
+      input[type="url"],
+      input[type="text"] {
+        width: 100%;
+        padding: 0.5rem;
+        margin-top: 0.25rem;
+      }
+      button {
+        margin-top: 0.5rem;
+        padding: 0.5rem 1rem;
+        cursor: pointer;
+      }
+      button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      #status {
+        margin: 1rem 0;
+        padding: 0.75rem;
+        background: #f0f0f0;
+        border-radius: 4px;
+        font-size: 0.9rem;
+      }
+      #results {
+        list-style: none;
+        padding: 0;
+        margin: 1rem 0 0;
+      }
+      #results li {
+        padding: 0.75rem;
+        margin-bottom: 0.5rem;
+        background: #f8f8f8;
+        border-radius: 4px;
+        border-left: 3px solid #0066cc;
+      }
+      #results li strong {
+        display: block;
+        margin-bottom: 0.25rem;
+      }
+      #results li small {
+        color: #666;
+      }
+      .search-row {
+        display: flex;
+        gap: 0.5rem;
+        margin-top: 0.5rem;
+      }
+      .search-row input {
+        flex: 1;
+      }
+      .note {
+        font-size: 0.9rem;
+        color: #444;
+        margin-top: 0.5rem;
+      }
+    </style>
+    <script type="importmap">
+      {
+        "imports": {
+          "@ai4data/search": "/dist/index.mjs",
+          "@ai4data/search/worker": "/dist/worker.mjs"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <h1>@ai4data/search — Hugging Face proxy</h1>
+    <p>
+      Embedding assets are loaded via <code>transformersRemoteHost</code> pointing at
+      <code>/api/hf-proxy/</code> (same origin). The demo server forwards that prefix to
+      <code>huggingface.co</code> so the worker never calls the Hub directly.
+    </p>
+    <p class="note">
+      From <code>packages/ai4data/search</code>, run
+      <code>npm run demo:proxy</code>, then open this page (served at
+      <code>http://localhost:5173/</code>).
+    </p>
+
+    <label for="manifestUrl">Manifest URL</label>
+    <input
+      type="url"
+      id="manifestUrl"
+      placeholder="https://example.com/data/collection/manifest.json"
+    />
+
+    <button id="connectBtn">Connect</button>
+    <div id="status">Enter a manifest URL and click Connect.</div>
+
+    <label for="query">Search</label>
+    <div class="search-row">
+      <input
+        type="text"
+        id="query"
+        placeholder="e.g. climate finance"
+        disabled
+      />
+      <button id="searchBtn" disabled>Search</button>
+    </div>
+
+    <ul id="results"></ul>
+
+    <script type="module">
+      import { SearchClient } from "@ai4data/search";
+
+      const origin = location.origin;
+      const workerUrl = `${origin}/dist/worker.mjs`;
+      /** Same-origin proxy; mirrors Hub paths under /api/hf-proxy/ */
+      const transformersRemoteHost = `${origin}/api/hf-proxy/`;
+
+      const manifestInput = document.getElementById("manifestUrl");
+      const connectBtn = document.getElementById("connectBtn");
+      const statusEl = document.getElementById("status");
+      const queryInput = document.getElementById("query");
+      const searchBtn = document.getElementById("searchBtn");
+      const resultsList = document.getElementById("results");
+
+      let client = null;
+
+      function setStatus(text) {
+        statusEl.textContent = text;
+      }
+
+      function setResults(items) {
+        resultsList.innerHTML = (items || [])
+          .map(
+            (r) =>
+              `<li><strong>${escapeHtml(r.title || String(r.id))}</strong><br><small>id: ${r.id} · score: ${(r.score ?? 0).toFixed(4)}</small></li>`,
+          )
+          .join("");
+      }
+
+      function escapeHtml(s) {
+        const div = document.createElement("div");
+        div.textContent = s;
+        return div.innerHTML;
+      }
+
+      function updateUI() {
+        if (!client) return;
+        setStatus(client.loadingMessage);
+        const ready = client.isIndexReady;
+        queryInput.disabled = !ready;
+        searchBtn.disabled = !ready;
+        if (ready)
+          setStatus(
+            client.isModelReady
+              ? "Ready (semantic + hybrid) — model via /api/hf-proxy/"
+              : "Index ready (lexical only)",
+          );
+      }
+
+      connectBtn.addEventListener("click", async () => {
+        const url = manifestInput.value.trim();
+        if (!url) {
+          setStatus("Please enter a manifest URL.");
+          return;
+        }
+        if (client) {
+          client.destroy();
+          client = null;
+        }
+        setStatus("Connecting…");
+        setResults([]);
+        queryInput.value = "";
+        connectBtn.disabled = true;
+        try {
+          client = await SearchClient.fromCDN(url, {
+            workerUrl,
+            transformersRemoteHost,
+          });
+          client.on("progress", updateUI);
+          client.on("index_ready", updateUI);
+          client.on("ready", updateUI);
+          client.on("error", updateUI);
+          client.on("results", ({ data }) => {
+            setResults(data);
+            updateUI();
+          });
+          const interval = setInterval(() => {
+            updateUI();
+            if (client?.isIndexReady) clearInterval(interval);
+          }, 500);
+          setTimeout(() => clearInterval(interval), 120000);
+        } catch (err) {
+          setStatus(`Error: ${err.message}`);
+        }
+        connectBtn.disabled = false;
+      });
+
+      searchBtn.addEventListener("click", () => {
+        const q = queryInput.value.trim();
+        if (!q || !client) return;
+        client.search(q, { topK: 10, mode: "hybrid" });
+        setStatus("Searching…");
+      });
+      queryInput.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") searchBtn.click();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/ai4data/search/demo/proxy-server.mjs
+++ b/packages/ai4data/search/demo/proxy-server.mjs
@@ -1,0 +1,170 @@
+/**
+ * Minimal static server + Hugging Face Hub reverse proxy for local CSP demos.
+ *
+ * Serves the package root (so /dist/* works after `npm run build`) and forwards:
+ *   GET /api/hf-proxy/<path>  →  https://huggingface.co/<path>
+ *
+ * Some tools use a different local prefix (commit in the path, not …/resolve/main/…):
+ *   GET /api/resolve-cache/models/<org>/<model>/<revision>/<file…>
+ *     → https://huggingface.co/<org>/<model>/resolve/<revision>/<file…>
+ * Query strings are not forwarded (HF raw files do not need them; bogus cache keys cause 404s).
+ *
+ * Redirects are followed **on the server** (fetch + redirect: follow). Hub files often 302 to
+ * cdn-lfs.huggingface.co; if we passed that through to the browser, the client would leave
+ * localhost and hit CSP blocks — endless orange redirects in DevTools.
+ *
+ * For local development only — do not expose this proxy on the public internet.
+ */
+
+import http from "http";
+import fs from "fs";
+import path from "path";
+import { Readable } from "stream";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, "..");
+const PORT = Number(process.env.PORT) || 5173;
+const HF_ORIGIN = "https://huggingface.co";
+
+/** Hop-by-hop / headers we must not forward when re-streaming the final response */
+const SKIP_RESPONSE_HEADER = new Set([
+  "connection",
+  "content-encoding",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+/**
+ * Fetch Hub URL with redirects resolved on the server, then stream the final body to the client.
+ * Prevents the browser from following 302s to huggingface.co / cdn-lfs (CSP / redirect chains).
+ */
+async function proxyFetchFollow(targetUrl, res, req) {
+  const ac = new AbortController();
+  res.on("close", () => ac.abort());
+  try {
+    const r = await fetch(targetUrl, {
+      redirect: "follow",
+      signal: ac.signal,
+      headers: {
+        "user-agent": req?.headers?.["user-agent"] || "ai4data-search-demo-proxy",
+        accept: req?.headers?.accept || "*/*",
+      },
+    });
+
+    const outHeaders = {};
+    r.headers.forEach((value, key) => {
+      const lower = key.toLowerCase();
+      if (lower === "content-security-policy") return;
+      if (SKIP_RESPONSE_HEADER.has(lower)) return;
+      outHeaders[key] = value;
+    });
+    outHeaders["access-control-allow-origin"] = "*";
+
+    res.writeHead(r.status, outHeaders);
+
+    if (!r.body) {
+      res.end();
+      return;
+    }
+
+    const nodeReadable = Readable.fromWeb(r.body);
+    nodeReadable.on("error", () => {
+      if (!res.writableEnded) res.destroy();
+    });
+    nodeReadable.pipe(res);
+  } catch (e) {
+    if (e?.name === "AbortError") return;
+    if (!res.headersSent) {
+      res.writeHead(502, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end(`Proxy error: ${e?.message ?? e}`);
+    }
+  }
+}
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".png": "image/png",
+  ".ico": "image/x-icon",
+};
+
+function safeFilePath(root, pathname) {
+  const stripped = decodeURIComponent(pathname).replace(/^\//, "");
+  const rel = path.normalize(stripped).replace(/^(\.\.(\/|\\|$))+/, "");
+  const full = path.join(root, rel);
+  const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
+  if (!full.startsWith(rootWithSep) && full !== root) return null;
+  return full;
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url || "/", `http://127.0.0.1:${PORT}`);
+
+  if (url.pathname.startsWith("/api/hf-proxy/")) {
+    const hfPath = url.pathname.slice("/api/hf-proxy".length) + url.search;
+    const target = HF_ORIGIN + hfPath;
+    void proxyFetchFollow(target, res, req);
+    return;
+  }
+
+  // Alternate path shape used by some hub helpers / tooling (not Xenova's default template).
+  // Example: /api/resolve-cache/models/avsolatorio/GIST-small-Embedding-v0/<commit>/config.json
+  if (url.pathname.startsWith("/api/resolve-cache/models/")) {
+    const rest = url.pathname.slice("/api/resolve-cache/models/".length);
+    const segments = rest.split("/").filter(Boolean);
+    if (segments.length >= 4) {
+      const org = segments[0];
+      const model = segments[1];
+      const revision = segments[2];
+      const fileInRepo = segments.slice(3).join("/");
+      const target = `${HF_ORIGIN}/${org}/${model}/resolve/${revision}/${fileInRepo}`;
+      void proxyFetchFollow(target, res, req);
+      return;
+    }
+    res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end(
+      "Bad /api/resolve-cache/models/ path. Expected /api/resolve-cache/models/<org>/<name>/<revision>/<file...>",
+    );
+    return;
+  }
+
+  let pathname = url.pathname === "/" ? "/demo/hf-proxy-demo.html" : url.pathname;
+  const filePath = safeFilePath(ROOT, pathname);
+  if (!filePath) {
+    res.writeHead(403);
+    res.end("Forbidden");
+    return;
+  }
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Not found");
+      return;
+    }
+    const ext = path.extname(filePath);
+    res.writeHead(200, { "Content-Type": MIME[ext] || "application/octet-stream" });
+    res.end(data);
+  });
+});
+
+server.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Open http://localhost:${PORT}/`);
+  // eslint-disable-next-line no-console
+  console.log(`HF proxy: /api/hf-proxy/ → ${HF_ORIGIN}/`);
+  // eslint-disable-next-line no-console
+  console.log(`HF proxy: /api/resolve-cache/models/… → ${HF_ORIGIN}/<org>/<model>/resolve/<rev>/…`);
+  // eslint-disable-next-line no-console
+  console.log("Run `npm run build` in this package first so /dist/* is available.");
+});

--- a/packages/ai4data/search/package.json
+++ b/packages/ai4data/search/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsup",
     "demo": "npm run build && npx serve . -p 5173",
+    "demo:proxy": "npm run build && node demo/proxy-server.mjs",
     "prepublishOnly": "npm run build",
     "test": "echo 'Add smoke test if desired'",
     "lint": "echo 'Add ESLint if desired'"

--- a/packages/ai4data/search/package.json
+++ b/packages/ai4data/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai4data/search",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Framework-agnostic semantic search client: HNSW, BM25, hybrid ranking in a Web Worker",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",

--- a/packages/ai4data/search/package.json
+++ b/packages/ai4data/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai4data/search",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Framework-agnostic semantic search client: HNSW, BM25, hybrid ranking in a Web Worker",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",

--- a/packages/ai4data/search/src/client/SearchClient.ts
+++ b/packages/ai4data/search/src/client/SearchClient.ts
@@ -44,6 +44,19 @@ export interface SearchClientOptions {
   /** If true, do not load or build BM25 even when the manifest has bm25_corpus (semantic-only). */
   skipBm25?: boolean
   /**
+   * Base URL passed to `@xenova/transformers` as `env.remoteHost` (default Hub is `https://huggingface.co/`).
+   * Point this at a same-origin proxy that forwards to the Hub so embedding downloads comply with CSP.
+   * `modelId` remains a full repo id (e.g. `org/model`); the proxy should mirror Hub paths:
+   * `…/org/model/resolve/{revision}/…` (see the package `demo/proxy-server.mjs` route `/api/hf-proxy/`).
+   * If another stack requests `/api/resolve-cache/models/…/{revision}/file`, use a proxy that maps that to the Hub
+   * (the same demo server supports that pattern). Relative URLs are resolved with `new URL(…, location.href)`.
+   */
+  transformersRemoteHost?: string
+  /**
+   * Optional `env.remotePathTemplate` override. Omit unless your proxy does not mirror the Hub path layout.
+   */
+  transformersRemotePathTemplate?: string
+  /**
    * Factory function that creates the Web Worker.
    * Defaults to the bundled search worker created via `new URL()`.
    * Override when you need a custom worker path (e.g. CDN, service worker proxy).
@@ -88,6 +101,13 @@ type MessageHandler<T extends WorkerOutboundMessage['type']> = (
  * ESM.sh returns a wrapper with imports that fail when run from a blob: URL; unpkg/jsDelivr
  * serve the raw dist/worker.mjs which is self-contained.
  */
+/** Resolve relative HF proxy base against the page; ensure trailing slash for Xenova pathJoin. */
+function resolveTransformersRemoteHost(raw: string): string {
+  const base = globalThis.location?.href ?? 'http://localhost/'
+  const u = new URL(raw, base).href
+  return u.endsWith('/') ? u : `${u}/`
+}
+
 function getBundledWorkerUrl(url: string): string {
   const esmMatch = url.match(/esm\.sh\/@ai4data\/search@([^/]+)\/worker/)
   if (esmMatch) {
@@ -206,6 +226,12 @@ export class SearchClient {
       skipModelLoad: opts.skipModelLoad,
       modelLoadDelaySeconds: opts.modelLoadDelaySeconds,
       skipBm25: opts.skipBm25,
+      ...(opts.transformersRemoteHost !== undefined && {
+        transformersRemoteHost: resolveTransformersRemoteHost(opts.transformersRemoteHost),
+      }),
+      ...(opts.transformersRemotePathTemplate !== undefined && {
+        transformersRemotePathTemplate: opts.transformersRemotePathTemplate,
+      }),
     }
     this.worker.postMessage(initMsg)
   }

--- a/packages/ai4data/search/src/client/SearchClient.ts
+++ b/packages/ai4data/search/src/client/SearchClient.ts
@@ -181,7 +181,7 @@ export class SearchClient {
   // ── Constructor ──────────────────────────────────────────────────────────────
 
   /**
-   * @param manifestUrl - Absolute or relative URL to `manifest.json`.
+   * @param manifestUrl - Absolute or relative URL to the collection manifest JSON (any filename, e.g. `search_manifest.json`).
    *   Relative URLs are resolved against `location.href`.
    * @param opts        - Optional configuration.
    */

--- a/packages/ai4data/search/src/types/worker.ts
+++ b/packages/ai4data/search/src/types/worker.ts
@@ -38,6 +38,17 @@ export interface WorkerInitMessage {
   modelLoadDelaySeconds?: number
   /** If true, do not load or build BM25 even when the manifest has bm25_corpus (semantic-only). */
   skipBm25?: boolean
+  /**
+   * Override `@xenova/transformers` `env.remoteHost` so model assets load from your origin or proxy
+   * (avoids CSP blocks on huggingface.co). Must mirror Hub paths unless `transformersRemotePathTemplate` is set.
+   * Absolute URL recommended; relative paths are resolved on the main thread before posting to the worker.
+   */
+  transformersRemoteHost?: string
+  /**
+   * Override `env.remotePathTemplate` (default `'{model}/resolve/{revision}/'`). Only needed if the proxy
+   * uses a different path layout than the Hugging Face Hub.
+   */
+  transformersRemotePathTemplate?: string
 }
 
 export interface WorkerSearchMessage {

--- a/packages/ai4data/search/src/workers/search.worker.ts
+++ b/packages/ai4data/search/src/workers/search.worker.ts
@@ -217,7 +217,9 @@ async function initIndex(
   manifest = (await resp.json()) as CollectionManifest;
   highlightsList = null;
 
-  baseUrl = manifestUrl.replace(/manifest\.json$/, "");
+  // Directory containing the manifest — any filename is allowed (not only manifest.json).
+  const manifestPathOnly = manifestUrl.split(/[?#]/)[0];
+  baseUrl = new URL(".", manifestPathOnly).href;
   if (!baseUrl.endsWith("/")) baseUrl += "/";
 
   if (manifest.search_mode === "flat") {

--- a/packages/ai4data/search/src/workers/search.worker.ts
+++ b/packages/ai4data/search/src/workers/search.worker.ts
@@ -56,6 +56,9 @@ let highlightsList: SearchResult[] | null = null;
 let flatCompareEngine: FlatEngine | null = null;
 let isModelReady = false;
 let isIndexReady = false;
+/** Set from `init`; applied in `loadModel` before `pipeline()` */
+let transformersRemoteHost: string | undefined;
+let transformersRemotePathTemplate: string | undefined;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -146,7 +149,19 @@ function buildBM25Engine(
 
 // ── Model loading ─────────────────────────────────────────────────────────────
 
+function applyTransformersRemoteEnv(): void {
+  if (transformersRemoteHost !== undefined) {
+    env.remoteHost = transformersRemoteHost.endsWith("/")
+      ? transformersRemoteHost
+      : `${transformersRemoteHost}/`;
+  }
+  if (transformersRemotePathTemplate !== undefined) {
+    env.remotePathTemplate = transformersRemotePathTemplate;
+  }
+}
+
 async function loadModel(modelId?: string): Promise<void> {
+  applyTransformersRemoteEnv();
   postMsg({
     type: "progress",
     phase: "model",
@@ -319,7 +334,11 @@ async function init(
   skipModelLoad?: boolean,
   modelLoadDelaySeconds?: number,
   skipBm25?: boolean,
+  remoteHost?: string,
+  remotePathTemplate?: string,
 ): Promise<void> {
+  transformersRemoteHost = remoteHost;
+  transformersRemotePathTemplate = remotePathTemplate;
   try {
     if (skipModelLoad) {
       // Load index + BM25 only (unless skipBm25); leave embedding model unloaded to test BM25 fallback.
@@ -427,6 +446,8 @@ self.onmessage = async (
         m.skipModelLoad,
         m.modelLoadDelaySeconds,
         m.skipBm25,
+        m.transformersRemoteHost,
+        m.transformersRemotePathTemplate,
       );
       break;
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dynamic = ["version"]
 
 requires-python = ">=3.11"
 dependencies = [
+	"fire>=0.6.0",
 	"requests>=2.32.3",
 	"pandas>=2.2.3",
 	"pycountry>=22.12.1",
@@ -66,7 +67,6 @@ anomaly = [
 # Semantic search
 search = [
   "sentence-transformers>=2.7.0",
-  "fire>=0.6.0",
   "scikit-learn>=1.4.2",
   "faiss-cpu>=1.7.4",
   "numpy>=1.24.0",

--- a/scripts/search/pipeline/01_fetch_and_prepare.py
+++ b/scripts/search/pipeline/01_fetch_and_prepare.py
@@ -11,7 +11,8 @@ Supported sources:
 
 For worldbank_api, each document is extracted as NADA schema (metadata_information,
 document_description, provenance) with top-level compatibility fields (title, abstract,
-content) for the embeddings pipeline. Output: metadata.json and metadata/document_<idno>.json.
+authors as a list of full names, content) for the embeddings pipeline. Output:
+metadata.json and metadata/document_<idno>.json.
 
 Usage examples:
   # Fetch all Policy Research Working Papers (NADA schema)
@@ -19,8 +20,8 @@ Usage examples:
     --source=worldbank_api \
     --doctype="Policy Research Working Paper" \
     --output_dir=data/prwp \
-    --content_fields="title,abstract" \
-    --preview_fields="idno,title,abstract,type,doi,url,date_published"
+    --content_fields="title,abstract,authors" \
+    --preview_fields="idno,title,abstract,authors,type,doi,url,date_published"
 
   # Fetch by docty_key (563787=WDR, 620265=PRWP)
   python 01_fetch_and_prepare.py \\
@@ -142,6 +143,7 @@ def _extract_wb_doc(
     Args:
         doc: Raw document dict from the World Bank API.
         content_field_list: Fields to concatenate into ``content`` for embedding.
+            Use ``authors`` to include comma-separated author full names from NADA.
         preview_field_list: Fields to include in compat_record for display.
         docty_key: Document type key (563787=WDR, 620265=PRWP).
 
@@ -158,13 +160,24 @@ def _extract_wb_doc(
     abstract = dd.get("abstract", "")
     idno = str(ts.get("idno", nada.get("metadata_information", {}).get("idno", "")))
 
-    # Compose content for embedding (title + abstract by default)
+    authors_raw = dd.get("authors") or []
+    author_names: list[str] = []
+    for a in authors_raw:
+        if isinstance(a, dict) and a.get("full_name"):
+            t = str(a["full_name"]).strip()
+            if t:
+                author_names.append(t)
+
+    # Compose content for embedding (title + abstract + authors by default)
     content_parts: list[str] = []
     for field in content_field_list:
         if field == "title":
             content_parts.append(title)
         elif field == "abstract":
             content_parts.append(abstract)
+        elif field == "authors":
+            if author_names:
+                content_parts.append(", ".join(author_names))
         else:
             val = dd.get(field) or ts.get(field)
             if val:
@@ -186,6 +199,7 @@ def _extract_wb_doc(
         "idno": idno,
         "title": title,
         "abstract": abstract,
+        "authors": author_names,
         "content": content,
         "type": dd.get("type", ""),
         "doi": doi,
@@ -451,8 +465,8 @@ def main(
     sheet_name: str | None = None,
     # Field configuration (comma-separated)
     id_field: str = "idno",
-    content_fields: str = "title,abstract",  # fields joined for embedding content
-    preview_fields: str = "idno,title,abstract,type,doi,url,date_published",
+    content_fields: str = "title,abstract,authors",  # fields joined for embedding content
+    preview_fields: str = "idno,title,abstract,authors,type,doi,url,date_published",
 ) -> None:
     """Entry point: fetch documents from the specified source and save metadata.json.
     World Bank API documents are extracted as NADA schema; also saved as metadata/document_<idno>.json.
@@ -469,7 +483,8 @@ def main(
         sheet_name: Sheet name for Excel files.
         id_field: Field name used as the document identifier.
         content_fields: Comma-separated field names to merge into the ``content``
-            text for embedding.
+            text for embedding. For ``worldbank_api``, ``authors`` is derived from
+            NADA ``document_description.authors`` (``full_name`` per author).
         preview_fields: Comma-separated field names to include in the output
             record for display purposes.
 

--- a/scripts/search/pipeline/02_generate_embeddings.py
+++ b/scripts/search/pipeline/02_generate_embeddings.py
@@ -21,7 +21,7 @@ Usage:
     --embeddings_path=data/avsolatorio__GIST-small-Embedding-v0__004__doc_embeddings.json \\
     --output_dir=data/prwp \\
     --id_field=idno \\
-    --content_field=abstract \\
+    --content_fields=abstract \\
     --title_field=title \\
     --preview_fields=idno,title,abstract,type,doi
 
@@ -31,13 +31,73 @@ Usage:
     --output_dir=data/prwp \\
     --model=nomic-ai/nomic-embed-text-v1.5 \\
     --matryoshka_dim=128
+
+  # Multiple fields for the embedding body (comma-separated); use dots for nested keys
+  python 02_generate_embeddings.py \\
+    --metadata_path=data/prwp/metadata.json \\
+    --output_dir=data/prwp \\
+    --content_fields=abstract,authors
 """
 
 import json
-import os
+from typing import Any
+
 import numpy as np
 import fire
 from pathlib import Path
+
+
+def _split_comma_list(spec: str | list | tuple) -> list[str]:
+    """Parse comma-separated field names; fire may pass tuples."""
+    if isinstance(spec, (list, tuple)):
+        return [str(f).strip() for f in spec if str(f).strip()]
+    return [f.strip() for f in str(spec).split(",") if f.strip()]
+
+
+def _get_path(doc: dict, path: str) -> Any:
+    """Value at dot-separated path (e.g. ``metadata.authors``). Missing → ``None``."""
+    cur: Any = doc
+    for part in path.strip().split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def _value_to_text(val: Any) -> str:
+    """Turn JSON values into a string for embedding (lists, dicts, scalars)."""
+    if val is None:
+        return ""
+    if isinstance(val, str):
+        return val.strip()
+    if isinstance(val, (int, float, bool)):
+        return str(val)
+    if isinstance(val, list):
+        if not val:
+            return ""
+        if all(isinstance(x, str) for x in val):
+            return ", ".join(x.strip() for x in val if x and str(x).strip())
+        return json.dumps(val, ensure_ascii=False)
+    if isinstance(val, dict):
+        return json.dumps(val, ensure_ascii=False)
+    return str(val)
+
+
+def _build_embedding_body(doc: dict, content_fields: str | list | tuple) -> str:
+    """Body text under the title: one or more dot-paths joined with blank lines."""
+    paths = _split_comma_list(content_fields)
+    chunks: list[str] = []
+    for path in paths:
+        t = _value_to_text(_get_path(doc, path))
+        if t:
+            chunks.append(t)
+    return "\n\n".join(chunks)
+
+
+def _first_content_path(content_fields: str | list | tuple) -> str:
+    """First path segment, for BM25 fallback when ``bm25_text_field`` is absent."""
+    paths = _split_comma_list(content_fields)
+    return paths[0] if paths else "abstract"
 
 
 def quantize_sq8(vec: np.ndarray) -> dict:
@@ -155,7 +215,7 @@ def main(
     batch_size: int = 64,
     # Field names (for embeddings_path or metadata_path)
     id_field: str = "idno",
-    content_field: str = "abstract",
+    content_fields: str | list | tuple = "abstract",
     title_field: str = "title",
     embedding_field: str = "embedding",
     preview_fields: str = "idno,title,abstract,type,doi",  # comma-separated
@@ -182,7 +242,10 @@ def main(
         model: HuggingFace model ID used when ``metadata_path`` is provided.
         batch_size: Encoding batch size for sentence-transformers.
         id_field: Field name for the document identifier.
-        content_field: Field name for the main text content used for encoding.
+        content_fields: Comma-separated dot-separated paths merged into the
+            embedding body (below the title), each non-empty value separated by
+            blank lines. Use a single path for one field (default ``abstract``),
+            e.g. ``abstract,authors`` or ``metadata.abstract``.
         title_field: Field name for the document title.
         embedding_field: Key holding the raw embedding list when loading from
             ``embeddings_path``.
@@ -228,7 +291,8 @@ def main(
             if "idno" in meta:
                 meta["idno"] = str(meta["idno"])
             meta["title"] = item.get(title_field, "")
-            meta["text"] = item.get(bm25_text_field, item.get(content_field, ""))
+            fb = _value_to_text(_get_path(item, _first_content_path(content_fields)))
+            meta["text"] = item.get(bm25_text_field, fb)
             metadata.append(meta)
 
         embeddings = np.array(embeddings_list, dtype=np.float32)
@@ -245,7 +309,7 @@ def main(
         texts = [
             (doc.get(title_field, "") or "")
             + "\n\n"
-            + (doc.get(content_field, "") or "")
+            + _build_embedding_body(doc, content_fields)
             for doc in docs
         ]
         print(f"  Encoding {len(texts)} documents with {model}...")
@@ -269,7 +333,8 @@ def main(
                     meta["idno"]
                 )  # normalize to string (match semantic-search shape)
             meta["title"] = doc.get(title_field, "")
-            meta["text"] = doc.get(bm25_text_field, doc.get(content_field, ""))
+            fb = _value_to_text(_get_path(doc, _first_content_path(content_fields)))
+            meta["text"] = doc.get(bm25_text_field, fb)
             metadata.append(meta)
 
         print(f"  Generated embeddings: shape={embeddings.shape}")

--- a/scripts/search/pipeline/03_build_index.py
+++ b/scripts/search/pipeline/03_build_index.py
@@ -206,7 +206,7 @@ def main(
     n_clusters: int | None = None,  # None = auto: max(10, sqrt(n_items))
     kmeans_niter: int = 30,
     # Preview fields to include in flat format (already written by 02_generate_embeddings.py)
-    preview_fields: str = "idno,title,abstract,type,doi",
+    preview_fields: str = "idno,title,abstract,authors,type,doi",
     # BM25 fields for manifest
     bm25_fields: str = "title,text",
     # Compression: "gzip" writes .json.gz and removes .json (smaller transfer).

--- a/scripts/search/pipeline/README.md
+++ b/scripts/search/pipeline/README.md
@@ -32,6 +32,16 @@ Key Python dependencies (see `pyproject.toml` / `uv.lock`):
 | `pandas` | Excel/CSV loading (optional) |
 | `openpyxl` | `.xlsx` support for pandas (optional) |
 
+**Search optional dependencies** — Steps **02** (embeddings) and **03** (FAISS / HNSW index) need packages from the **`search`** extra in `pyproject.toml` (`sentence-transformers`, `faiss-cpu`, etc.). Install them from the repository root:
+
+```bash
+uv sync --extra search
+```
+
+(or `uv pip install -e ".[search]"` if you install editable another way).
+
+Step **01** (fetch / prepare) only needs the base environment plus `requests` / `pandas` as listed above; run **`uv sync --extra search`** before a full three-step pipeline or before running `02_generate_embeddings.py` / `03_build_index.py` alone.
+
 ---
 
 ## Scripts
@@ -61,8 +71,8 @@ display fields.
 | `--input_file` | — | Path to `.xlsx`, `.csv`, or `.json` file |
 | `--sheet_name` | — | Sheet name for Excel inputs |
 | `--id_field` | `idno` | Column/key used as document ID |
-| `--content_fields` | `title,abstract` | Comma-separated fields merged into embedding text |
-| `--preview_fields` | `idno,title,abstract,type,doi,url,date_published` | Fields to keep for display |
+| `--content_fields` | `title,abstract,authors` | Comma-separated fields merged into embedding text (WB: `authors` from API) |
+| `--preview_fields` | `idno,title,abstract,authors,type,doi,url,date_published` | Fields to keep for display |
 
 **Output:** `{output_dir}/metadata.json`
 
@@ -89,7 +99,7 @@ set this flag for standard models like `GIST-small-Embedding-v0`.
 | `--model` | `avsolatorio/GIST-small-Embedding-v0` | HuggingFace model ID |
 | `--batch_size` | `64` | Encoding batch size |
 | `--id_field` | `idno` | Document ID field |
-| `--content_field` | `abstract` | Field used as main content text |
+| `--content_fields` | `abstract` | Comma-separated dot-paths for the body text (below title), e.g. `abstract,authors` |
 | `--title_field` | `title` | Field used as title |
 | `--preview_fields` | `idno,title,abstract,type,doi` | Fields in flat index |
 | `--matryoshka_dim` | `None` | Truncate to this many dims (MRL models only) |

--- a/scripts/search/pipeline/pipeline.py
+++ b/scripts/search/pipeline/pipeline.py
@@ -84,8 +84,8 @@ def main(
     input_file: str | None = None,
     sheet_name: str | None = None,
     id_field: str = "idno",
-    content_fields: str = "title,abstract",
-    preview_fields: str = "idno,title,abstract,type,doi,url,date_published",
+    content_fields: str = "title,abstract,authors",
+    preview_fields: str = "idno,title,abstract,authors,type,doi,url,date_published",
     bm25_fields: str = "title,text",
     max_docs: int = 0,
     # Step 2: embedding
@@ -190,15 +190,20 @@ def main(
         print("\nStep 2: Generating embeddings and quantizing...")
         embed_mod = _load_module("embed", pipeline_dir / "02_generate_embeddings.py")
         meta_path = str(output_path / "metadata.json")
+        # Step 01 merges title + body fields into `content`; step 02 encodes
+        # title_field + body paths. Omit a leading title path so we do not
+        # duplicate the title (matches former content_field=split(",")[1]).
+        _parts = [p.strip() for p in str(content_fields).split(",") if p.strip()]
+        if _parts and _parts[0] == title_field.strip():
+            _parts = _parts[1:]
+        embed_body_fields = ",".join(_parts) if _parts else "abstract"
         embed_mod.main(
             metadata_path=meta_path,
             output_dir=str(output_path),
             model=model,
             batch_size=batch_size,
             id_field=id_field,
-            content_field=content_fields.split(",")[1]
-            if "," in content_fields
-            else content_fields,
+            content_fields=embed_body_fields,
             title_field=title_field,
             preview_fields=preview_fields,
             matryoshka_dim=matryoshka_dim,


### PR DESCRIPTION
### Summary

Improves the `@ai4data/search` client and the search indexing pipeline so browser apps can load embedding models behind CSP, collection URLs work for non-`manifest.json` manifests, and embeddings can be built from multiple metadata fields (including authors).

### Changes

- **Configurable Hugging Face proxy for the search worker**  
  Adds `transformersRemoteHost` and optional `transformersRemotePathTemplate` on `SearchClient`, wired through to the worker so `@xenova/transformers` can use a same-origin proxy instead of hitting the Hub directly (helps with Content Security Policy). Relative bases are resolved against `location` and normalized with a trailing slash.

- **Demo proxy and docs**  
  Adds `demo/proxy-server.mjs`, `demo/hf-proxy-demo.html`, and expands `packages/ai4data/search/README.md` to document proxy usage and local testing.

- **Manifest / collection URL handling**  
  Fixes derivation of the collection base URL so it works when the manifest file is not named `manifest.json` (e.g. `search_manifest.json`). Constructor docs updated accordingly.

- **Embedding pipeline: multi-field content**  
  Replaces single `--content_field` with `--content_fields` (comma-separated, optional dot paths for nested keys). Builds the embedding body from multiple segments (e.g. abstract + authors) with sensible stringification for lists/objects. Related updates in `01_fetch_and_prepare.py`, `03_build_index.py`, `pipeline.py`, and `scripts/search/pipeline/README.md`.

- **Housekeeping**  
  Small updates to `.gitignore`, `package-lock.json`, `pyproject.toml`, and `packages/ai4data/search/package.json` as needed for the above.

### How to test

- Run the demo proxy and HTML demo per `packages/ai4data/search/README.md`.
- Build an index with the updated pipeline using `--content_fields=abstract,authors` (or your real field list) and confirm the client loads against a proxied `transformersRemoteHost` if your app uses strict CSP.
