### PR TITLE
feat(discovery): ship ai4data[discovery] — catalog, metadata pipeline, and embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_build/
 sample.doc.json
 *.DS_Store
 data/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,9 @@ discovery = [
   "langchain-core>=0.3.0",
   "langchain-community>=0.3.0",
   "langchain-huggingface>=0.1.0",
+  "langchain-text-splitters>=1.1.2",
+  "sentence-transformers>=5.4.1",
+  "torch>=2.0.0",
   "tika>=2.6.0",
   "pymupdf>=1.23.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,26 @@ metadata = [
   "tqdm>=4.65.0",
 ]
 
+# NADA discovery (catalog fetch, metadata templates, PDF helpers)
+discovery = [
+  "httpx>=0.27.0",
+  "backoff>=2.2.1",
+  "tqdm>=4.65.0",
+  "pydantic>=2.0.0",
+  "pydantic-settings>=2.0.0",
+  "python-dotenv>=1.0.0",
+  "jinja2>=3.0.0",
+  "numpy>=1.24.0",
+  "pandas>=2.2.3",
+  "scikit-learn>=1.3.0",
+  "beautifulsoup4>=4.12.0",
+  "langchain-core>=0.3.0",
+  "langchain-community>=0.3.0",
+  "langchain-huggingface>=0.1.0",
+  "tika>=2.6.0",
+  "pymupdf>=1.23.0",
+]
+
 # Metadata reviewer — base (no LLM provider)
 metadata-reviewer = [
   "autogen-core>=0.7.5",
@@ -131,6 +151,7 @@ all = [
 	"ai4data[anomaly]",
 	"ai4data[search]",
 	"ai4data[metadata]",
+	"ai4data[discovery]",
 	"ai4data[metadata-reviewer]",
 ]
 

--- a/src/ai4data/__init__.py
+++ b/src/ai4data/__init__.py
@@ -11,6 +11,9 @@ This package provides various AI-powered tools for data analysis:
 - metadata: Metadata quality assessment and augmentation
   Install with: uv pip install ai4data[metadata]
 
+- discovery: NADA catalog, metadata templates, and related discovery helpers
+  Install with: uv pip install ai4data[discovery]
+
 For all capabilities:
   uv pip install ai4data[all]
 """
@@ -27,11 +30,13 @@ except PackageNotFoundError:
 # if dependencies are not installed until you actually use the features
 from . import data_use
 from . import anomaly
+from . import discovery
 from . import metadata
 
 __all__ = [
     "__version__",
     "data_use",
     "anomaly",
+    "discovery",
     "metadata",
 ]

--- a/src/ai4data/discovery/README.md
+++ b/src/ai4data/discovery/README.md
@@ -28,6 +28,29 @@ Defined in [`config.py`](./config.py) (`EmbeddingTemplatesConfig`). Controls whe
 |----------|-----------|-------------|
 | `AI4DATA_EMBEDDING_CONTENT_TEMPLATES_PATH` | No | Directory containing per-type template folders (`indicator`, `document`, …). Defaults to `metadata/templates` next to `config.py` inside the installed package. |
 
+The `AI4DATA_EMBEDDING_` prefix is shared with **embedding inference** (below). Unrecognized keys are ignored per settings class.
+
+### Embedding inference (`AI4DATA_EMBEDDING_*`)
+
+Defined in [`config.py`](./config.py) (`EmbeddingInferenceConfig`). Used by [`embeddings.py`](./embeddings.py) for `HuggingFaceEmbeddings` and the token text splitter when you call [`wiring.register_discovery_processors()`](./wiring.py) (see below). The `discovery` extra installs `torch`, `sentence-transformers` (>=5.4.1), and `langchain-text-splitters` needed for those code paths.
+
+| Variable | Required | Description |
+|----------|-----------|-------------|
+| `AI4DATA_EMBEDDING_MODEL` | No | HuggingFace model id (default: `avsolatorio/GIST-Embedding-v0`). |
+| `AI4DATA_EMBEDDING_BATCH_SIZE` | No | Encode batch size (default: `64`). |
+| `AI4DATA_EMBEDDING_DEVICE` | No | Device string, e.g. `cuda`, `mps`, `cpu`. If unset, auto-pick cuda → mps → cpu. |
+| `AI4DATA_EMBEDDING_SHOW_PROGRESS` | No | Progress bars during encoding (default: `true`). |
+
+**Wiring (required for `embed_documents` / `get_doc_reps`):** call once at process startup (not on import):
+
+```python
+from ai4data.discovery.wiring import register_discovery_processors
+
+register_discovery_processors()
+```
+
+To clear cached models in long-running jobs or tests, use `ai4data.discovery.embeddings.clear_embedding_caches()`.
+
 ### Local data / cache (`AI4DATA_DISCOVERY_*`)
 
 Defined in [`config.py`](./config.py) (`DiscoveryDataConfig`). Used by [`paths.py`](./paths.py) for `metadata_ids`, `metadata_cache`, `document_cache`, and related subpaths.

--- a/src/ai4data/discovery/README.md
+++ b/src/ai4data/discovery/README.md
@@ -1,0 +1,43 @@
+# `ai4data.discovery`
+
+NADA (IHSN) catalog HTTP helpers, cached metadata/PDF workflows, Jinja templates for embedding text, and PDF/chunk helpers.
+
+Install: `uv pip install ai4data[discovery]`
+
+## Environment variables
+
+Configuration uses [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/). Variable names are **case-insensitive** on all platforms. Prefixes are fixed per settings group.
+
+On import, `discovery.config` calls `load_dotenv()`, so a **`.env`** file in the current working directory is loaded automatically when present.
+
+### Catalog (`AI4DATA_METADATA_CATALOG_*`)
+
+Defined in [`config.py`](./config.py) (`MetadataCatalogConfig`). Used by [`catalog/http.py`](./catalog/http.py), [`catalog/data_api.py`](./catalog/data_api.py), and thumbnail URLs in [`metadata/utils.py`](./metadata/utils.py).
+
+| Variable | Required | Description |
+|----------|-----------|-------------|
+| `AI4DATA_METADATA_CATALOG_URL` | No | Base URL for the NADA catalog UI/API (default: `https://data-compass.ihsn.org/index.php`). Search and JSON endpoints are built from this value. |
+| `AI4DATA_METADATA_CATALOG_THUMBNAIL_URL` | No | Format string for document thumbnails; must include `{db_id}` (default matches NADA public thumbnails). |
+| `AI4DATA_METADATA_CATALOG_X_API_KEY` | Only for authenticated APIs | API key sent as header `x-api-key` by [`catalog/data_api.py`](./catalog/data_api.py). Public catalog HTTP in `http.py` does not attach this header; set it if you call authenticated resources. |
+
+### Embedding templates (`AI4DATA_EMBEDDING_*`)
+
+Defined in [`config.py`](./config.py) (`EmbeddingTemplatesConfig`). Controls where Jinja2 templates live for [`metadata/templates/render.py`](./metadata/templates/render.py).
+
+| Variable | Required | Description |
+|----------|-----------|-------------|
+| `AI4DATA_EMBEDDING_CONTENT_TEMPLATES_PATH` | No | Directory containing per-type template folders (`indicator`, `document`, …). Defaults to `metadata/templates` next to `config.py` inside the installed package. |
+
+### Local data / cache (`AI4DATA_DISCOVERY_*`)
+
+Defined in [`config.py`](./config.py) (`DiscoveryDataConfig`). Used by [`paths.py`](./paths.py) for `metadata_ids`, `metadata_cache`, `document_cache`, and related subpaths.
+
+| Variable | Required | Description |
+|----------|-----------|-------------|
+| `AI4DATA_DISCOVERY_DATA_PATH` | No | Root directory for discovery caches. If unset, defaults to `ai4data/data` under the installed package (in this repo from source: `src/ai4data/data`). |
+
+**Precedence:** `init_discovery_paths(Path("..."))` with a non-`None` path always wins over the env var. Calling `init_discovery_paths(None)` (or `init_discovery_paths()` with default) applies `_default_data_root()`, which respects `AI4DATA_DISCOVERY_DATA_PATH` when set.
+
+### Optional: Apache Tika
+
+[`processors/document.py`](./processors/document.py) uses **`tika`** for `tika_parse_pdf`. The Python package may require a running Tika server or local JAR; see [tika-python](https://github.com/chrismattmann/tika-python) documentation for server/JVM setup. That is runtime configuration outside `ai4data.discovery.config`.

--- a/src/ai4data/discovery/README.md
+++ b/src/ai4data/discovery/README.md
@@ -18,7 +18,8 @@ Defined in [`config.py`](./config.py) (`MetadataCatalogConfig`). Used by [`catal
 |----------|-----------|-------------|
 | `AI4DATA_METADATA_CATALOG_URL` | No | Base URL for the NADA catalog UI/API (default: `https://data-compass.ihsn.org/index.php`). Search and JSON endpoints are built from this value. |
 | `AI4DATA_METADATA_CATALOG_THUMBNAIL_URL` | No | Format string for document thumbnails; must include `{db_id}` (default matches NADA public thumbnails). |
-| `AI4DATA_METADATA_CATALOG_X_API_KEY` | Only for authenticated APIs | API key sent as header `x-api-key` by [`catalog/data_api.py`](./catalog/data_api.py). Public catalog HTTP in `http.py` does not attach this header; set it if you call authenticated resources. |
+| `AI4DATA_METADATA_CATALOG_X_API_KEY` | Only for authenticated APIs | API key sent as header `x-api-key`. Used by [`catalog/data_api.py`](./catalog/data_api.py), and — when set — also attached by [`catalog/http.py`](./catalog/http.py) (search, JSON metadata) and [`metadata/document_fetch.py`](./metadata/document_fetch.py) (PDF downloads). For PDF downloads the header is only sent when the URL's host matches the configured catalog host (or is allow-listed via `AI4DATA_METADATA_CATALOG_X_API_KEY_HOSTS`), so the credential is never sent to third-party hosts embedded as external resources. |
+| `AI4DATA_METADATA_CATALOG_X_API_KEY_HOSTS` | No | Comma-separated list of additional hostnames allowed to receive `x-api-key` for catalog-resolved downloads (e.g. `training.ihsn.org`). The catalog host itself is always allowed; use this when downloads are served from a separate subdomain. |
 
 ### Embedding templates (`AI4DATA_EMBEDDING_*`)
 

--- a/src/ai4data/discovery/__init__.py
+++ b/src/ai4data/discovery/__init__.py
@@ -1,0 +1,5 @@
+"""Discovery-facing integrations (e.g. NADA catalog HTTP and batch jobs).
+
+Filesystem layout for discovery caches and id lists: :mod:`ai4data.discovery.paths`.
+Catalog API URLs and embedding-template root: :mod:`ai4data.discovery.config`.
+"""

--- a/src/ai4data/discovery/auth.py
+++ b/src/ai4data/discovery/auth.py
@@ -1,4 +1,4 @@
-"""HTTP authentication headers for NADA / IHSN catalog calls and PDF downloads.
+"""HTTP authentication headers and cookies for NADA / IHSN catalog calls and PDF downloads.
 
 The NADA catalog accepts ``x-api-key`` as the authentication header. We attach it from
 :attr:`MetadataCatalogConfig.x_api_key` (env ``AI4DATA_METADATA_CATALOG_X_API_KEY``) to:
@@ -6,6 +6,12 @@ The NADA catalog accepts ``x-api-key`` as the authentication header. We attach i
 - catalog endpoints — always (search, JSON metadata), and
 - PDF download URLs — only when the URL's host is the configured catalog host (or is
   explicitly allow-listed via ``AI4DATA_METADATA_CATALOG_X_API_KEY_HOSTS``).
+
+Some NADA instances (notably the IHSN training catalog) gate file downloads behind a
+logged-in PHP session rather than an API key. For those cases,
+:attr:`MetadataCatalogConfig.cookies` (env ``AI4DATA_METADATA_CATALOG_COOKIES``) carries a
+``name=value; name=value`` cookie string that is attached with the same host scoping as
+the API key.
 
 The host scoping prevents the credential from being sent to third-party hosts that the
 catalog may embed as external resources (e.g. a `World Bank <https://worldbank.org>`_
@@ -64,4 +70,55 @@ def get_catalog_auth_headers(url: str | None = None) -> dict[str, str]:
         return {X_API_KEY_HEADER: api_key}
     if target in allowed_api_key_hosts():
         return {X_API_KEY_HEADER: api_key}
+    return {}
+
+
+def _parse_cookie_string(raw: str | None) -> dict[str, str]:
+    """Parse a ``name=value; name=value`` cookie string into a dict.
+
+    Tolerant of stray whitespace and empty segments. Returns an empty dict for ``None``
+    or strings with no ``name=value`` pairs.
+    """
+    if not raw:
+        return {}
+    out: dict[str, str] = {}
+    for part in raw.split(";"):
+        if "=" not in part:
+            continue
+        name, value = part.split("=", 1)
+        name = name.strip()
+        if name:
+            out[name] = value.strip()
+    return out
+
+
+def get_catalog_cookies(url: str | None = None) -> dict[str, str]:
+    """Build the cookie dict for an outgoing HTTP call to the catalog.
+
+    Mirrors the host-scoping logic of :func:`get_catalog_auth_headers`.
+
+    Parameters
+    ----------
+    url:
+        The full URL the request will be sent to. Pass ``None`` for endpoints that always
+        hit the catalog (search, JSON metadata) — cookies are sent unconditionally when
+        configured. For arbitrary URLs (e.g. download URLs harvested from the catalog),
+        cookies are sent only when the URL's host is allow-listed (catalog host or
+        :attr:`MetadataCatalogConfig.x_api_key_hosts`).
+
+    Returns
+    -------
+    dict[str, str]
+        Parsed cookie dict when authorized, otherwise an empty dict.
+    """
+    raw = metadata_catalog.cookies
+    if not raw:
+        return {}
+    if url is None:
+        return _parse_cookie_string(raw)
+    target = urlparse(url).netloc
+    if not target:
+        return _parse_cookie_string(raw)
+    if target in allowed_api_key_hosts():
+        return _parse_cookie_string(raw)
     return {}

--- a/src/ai4data/discovery/auth.py
+++ b/src/ai4data/discovery/auth.py
@@ -1,0 +1,67 @@
+"""HTTP authentication headers for NADA / IHSN catalog calls and PDF downloads.
+
+The NADA catalog accepts ``x-api-key`` as the authentication header. We attach it from
+:attr:`MetadataCatalogConfig.x_api_key` (env ``AI4DATA_METADATA_CATALOG_X_API_KEY``) to:
+
+- catalog endpoints — always (search, JSON metadata), and
+- PDF download URLs — only when the URL's host is the configured catalog host (or is
+  explicitly allow-listed via ``AI4DATA_METADATA_CATALOG_X_API_KEY_HOSTS``).
+
+The host scoping prevents the credential from being sent to third-party hosts that the
+catalog may embed as external resources (e.g. a `World Bank <https://worldbank.org>`_
+hosted PDF returned in ``external_resources`` for an NADA record).
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from .config import metadata_catalog
+
+X_API_KEY_HEADER = "x-api-key"
+
+
+def _split_hosts(value: str | None) -> set[str]:
+    if not value:
+        return set()
+    return {h.strip() for h in value.split(",") if h.strip()}
+
+
+def allowed_api_key_hosts() -> set[str]:
+    """Return the set of hostnames that may receive the ``x-api-key`` header."""
+    catalog_host = urlparse(metadata_catalog.url).netloc
+    hosts = {catalog_host} if catalog_host else set()
+    hosts.update(_split_hosts(metadata_catalog.x_api_key_hosts))
+    return hosts
+
+
+def get_catalog_auth_headers(url: str | None = None) -> dict[str, str]:
+    """Build the ``x-api-key`` header dict for an outgoing HTTP call.
+
+    Parameters
+    ----------
+    url:
+        The full URL the request will be sent to. Pass ``None`` for endpoints that always hit
+        the catalog (search, JSON metadata) — the header is sent unconditionally when
+        configured. For arbitrary URLs (e.g. download URLs harvested from the catalog), the
+        header is sent only when the URL's host is allow-listed (catalog host or
+        :attr:`MetadataCatalogConfig.x_api_key_hosts`).
+
+    Returns
+    -------
+    dict[str, str]
+        ``{"x-api-key": ...}`` when authorized, otherwise an empty dict.
+    """
+    api_key = metadata_catalog.x_api_key
+    if not api_key:
+        return {}
+    if url is None:
+        return {X_API_KEY_HEADER: api_key}
+    target = urlparse(url).netloc
+    if not target:
+        # Relative URL — caller is responsible for prepending the catalog base, so treat as
+        # catalog-local.
+        return {X_API_KEY_HEADER: api_key}
+    if target in allowed_api_key_hosts():
+        return {X_API_KEY_HEADER: api_key}
+    return {}

--- a/src/ai4data/discovery/catalog/README.md
+++ b/src/ai4data/discovery/catalog/README.md
@@ -1,0 +1,33 @@
+# `ai4data.discovery.catalog`
+
+Public surface for **NADA** metadata: HTTP client, batch jobs, and ids used by downstream packages (e.g. `nada-opensearch`).
+
+## Modules
+
+| Module | Role |
+|--------|------|
+| `http.py` | Catalog HTTP API: `get_metadata_json`, `search_metadata`, `get_ids_type`, `get_metadata_ids`. |
+| `batch.py` | Save id lists, `scrape_all_ids`, `scrape_all_metadata`, Fire `main`. Run: `python -m ai4data.discovery.catalog.batch`. |
+| `data_api.py` | Authenticated JSON GET (`x-api-key`) for separate IHSN/API resources. |
+| `langdoc_id.py` | `get_langdoc_uuid` and UUID helper for chunk ids. |
+| `__init__.py` | Re-exports HTTP + `get_langdoc_uuid`. Import `MetadataLoader` / `get_metadata_langdocs` from `ai4data.discovery.metadata.handler` (avoiding a circular import). |
+
+## Related (not in `discovery/catalog/`)
+
+- **PDF download/cache** for document metadata: `ai4data.discovery.metadata.document_fetch` (`cache_download_pdf`, `download_pdf`).
+
+## Legacy shims
+
+`ai4data.catalog` re-exports this package for backward compatibility. `ai4data.scraper.metadata`, `ai4data.scraper.document`, and `ai4data.scraper.data_api` also shim older paths. Prefer imports from `ai4data.discovery.catalog`.
+
+## Consumers
+
+- `nada-opensearch` uses `ai4data.discovery.catalog` for HTTP + loader-related exports.
+
+## Maintenance
+
+Update `discovery/catalog/http.py` when catalog REST behavior changes. Batch CLI flags live in `discovery/catalog/batch.py`.
+
+## Configuration
+
+Environment variables for the catalog URL, API key, and related settings are documented in [`../README.md`](../README.md).

--- a/src/ai4data/discovery/catalog/__init__.py
+++ b/src/ai4data/discovery/catalog/__init__.py
@@ -1,0 +1,27 @@
+"""
+Stable integration surface for **NADA** metadata used by downstream
+packages (e.g. ``nada-opensearch``).
+
+**In this package**
+
+- :mod:`ai4data.discovery.catalog.http` — catalog HTTP API (fetch JSON, search, list ids).
+
+- :mod:`ai4data.discovery.catalog.langdoc_id` — ``get_langdoc_uuid`` and UUID helper.
+
+**Related (import from** :mod:`ai4data.discovery.metadata.handler` **):** ``MetadataLoader``, ``get_metadata_langdocs``. Those are not re-exported here to avoid a circular import with :mod:`ai4data.discovery.metadata.handler` (which uses :func:`ai4data.discovery.catalog.http.get_metadata_json`).
+
+``MetadataLoader`` uses :func:`ai4data.discovery.catalog.http.get_metadata_json` for fetches.
+"""
+
+from __future__ import annotations
+
+from .http import get_ids_type, get_metadata_ids, get_metadata_json, search_metadata
+from .langdoc_id import get_langdoc_uuid
+
+__all__ = [
+    "get_metadata_json",
+    "get_metadata_ids",
+    "get_ids_type",
+    "search_metadata",
+    "get_langdoc_uuid",
+]

--- a/src/ai4data/discovery/catalog/batch.py
+++ b/src/ai4data/discovery/catalog/batch.py
@@ -1,0 +1,138 @@
+"""
+Batch jobs and Fire CLI for syncing metadata IDs and JSON from the catalog.
+
+Prefer importing from here instead of the legacy ``ai4data.scraper.metadata`` shim.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from fire import Fire
+from tqdm.auto import tqdm
+
+from ..paths import get_metadata_ids_path
+from .http import get_metadata_ids, get_metadata_json, search_metadata
+
+
+def save_metadata_ids(metadata_ids: list, dtype: str) -> None:
+    """
+    Save the metadata IDs to a JSON file.
+
+    Args:
+        metadata_ids (list): A list of metadata ID dictionaries to save.
+        dtype (str): The type of metadata (e.g., 'indicator', 'document').
+    """
+    if metadata_ids is None or len(metadata_ids) == 0:
+        return
+
+    fpath = get_metadata_ids_path(dtype)
+    fpath.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(fpath, "w") as f:
+        json.dump(metadata_ids, f, indent=2)
+
+
+def scrape_all_ids(
+    get_metadata_ids_func: Callable = get_metadata_ids,
+    search_metadata_func: Callable = search_metadata,
+    save_metadata_ids_func: Callable = save_metadata_ids,
+    **kwargs,
+):
+    """
+    Scrape all metadata IDs from the metadata catalog based on the provided parameters.
+
+    Args:
+        get_metadata_ids_func (Callable, optional): Function or task to fetch metadata IDs.
+        search_metadata_func (Callable, optional): Function or task to search metadata.
+        save_metadata_ids_func (Callable, optional): Function or task to save metadata IDs.
+        **kwargs: Arbitrary keyword arguments representing search parameters.
+    """
+    params = kwargs
+
+    assert "ps" in params, "The number of items per page is required"
+    assert "type" in params, "The type of metadata is required, e.g., timeseries, document, geospatial, etc."
+
+    if params["type"] == "indicator":
+        params["type"] = "timeseries"
+    if params["type"] == "microdata":
+        params["type"] = "survey"
+
+    dtype = params["type"]
+    if dtype == "timeseries":
+        dtype = "indicator"
+    elif dtype == "survey":
+        dtype = "microdata"
+
+    metadata_ids = get_metadata_ids_func(params, search_metadata_func=search_metadata_func)
+    print(f"Total metadata ids: {len(metadata_ids)}")
+
+    save_metadata_ids_func(metadata_ids, dtype)
+
+
+def scrape_all_metadata(
+    get_metadata_json_func: Callable = get_metadata_json,
+    get_metadata_ids_func: Callable = get_metadata_ids,
+    search_metadata_func: Callable = search_metadata,
+    save_metadata_ids_func: Callable = save_metadata_ids,
+    **kwargs,
+):
+    """
+    Scrape all metadata from the metadata catalog based on the provided parameters.
+
+    Args:
+        get_metadata_func (Callable, optional): Function or task to fetch metadata.
+        get_metadata_ids_func (Callable, optional): Function or task to fetch metadata IDs.
+        search_metadata_func (Callable, optional): Function or task to search metadata.
+        save_metadata_ids_func (Callable, optional): Function or task to save metadata IDs.
+        **kwargs: Arbitrary keyword arguments representing search parameters.
+    """
+
+    skip_errors = kwargs.get("skip_errors", False)
+
+    scrape_all_ids(
+        get_metadata_ids_func=get_metadata_ids_func,
+        search_metadata_func=search_metadata_func,
+        save_metadata_ids_func=save_metadata_ids_func,
+        **kwargs,
+    )
+
+    dtype = kwargs.get("type", "timeseries")
+    force = kwargs.get("force", False)
+
+    if dtype == "indicator":
+        dtype = "timeseries"
+
+    fpath = get_metadata_ids_path(dtype)
+
+    with open(fpath) as f:
+        metadata_ids = json.load(f)
+
+    print(f"Total metadata ids: {len(metadata_ids)}")
+
+    for metadata_id in tqdm(metadata_ids):
+        idno = metadata_id["idno"]
+        metadata_type = metadata_id["type"]
+
+        try:
+            _ = get_metadata_json_func(idno=idno, metadata_type=metadata_type, force=force, load_exists=False)
+        except Exception as e:
+            print(f"Error fetching metadata for {idno}: {e}")
+
+            if not skip_errors:
+                raise e
+
+
+def main(action: str, **kwargs):
+    if action == "scrape_all_metadata":
+        scrape_all_metadata(**kwargs)
+    elif action == "scrape_all_ids":
+        scrape_all_ids(**kwargs)
+    else:
+        raise ValueError(f"Invalid action: {action}")
+
+
+if __name__ == "__main__":
+    # uv run python -m ai4data.discovery.catalog.batch --action=scrape_all_ids type=indicator ps=100
+    Fire(main)

--- a/src/ai4data/discovery/catalog/data_api.py
+++ b/src/ai4data/discovery/catalog/data_api.py
@@ -1,0 +1,21 @@
+"""
+Authenticated GET helper for NADA / IHSN JSON APIs (``x-api-key``).
+
+Separate from :mod:`ai4data.discovery.catalog.http` (public catalog JSON + search).
+"""
+
+from __future__ import annotations
+
+import requests
+
+from ..config import metadata_catalog
+
+
+def get_resource(url: str, verify: bool = True, timeout: float = 2.0):
+    headers = {
+        "x-api-key": metadata_catalog.x_api_key,
+    }
+    response = requests.request("get", url, verify=verify, timeout=timeout, headers=headers)
+    response.raise_for_status()
+
+    return response.json()["data"]

--- a/src/ai4data/discovery/catalog/http.py
+++ b/src/ai4data/discovery/catalog/http.py
@@ -16,7 +16,13 @@ from ..config import METADATA_CATALOG_URL
 from ..paths import get_metadata_cache_path
 
 
-def get_metadata_json(idno: str, metadata_type: str = None, force: bool = False, load_exists: bool = True) -> dict:
+def get_metadata_json(
+    idno: str,
+    metadata_type: str = None,
+    force: bool = False,
+    load_exists: bool = True,
+    include_resources: bool = False,
+) -> dict:
     """
     Retrieve metadata from a cache or fetch it from the catalog if not cached or if forced.
 
@@ -25,12 +31,17 @@ def get_metadata_json(idno: str, metadata_type: str = None, force: bool = False,
         metadata_type (str, optional): Used for caching. If None, caching is bypassed.
         force (bool, optional): If True, forces a fresh retrieval.
         load_exists (bool, optional): If True, load from cache when present.
-
+        include_resources (bool, optional): If True, include the resources in the metadata. Defaults to False.
     Returns:
         dict: The metadata associated with the given ID number.
     """
-    cache_path = get_metadata_cache_path(idno, metadata_type) if metadata_type else None
-
+    cache_path = (
+        get_metadata_cache_path(
+            idno, metadata_type, include_resources=include_resources
+        )
+        if metadata_type
+        else None
+    )
     if cache_path and not force and cache_path.exists():
         try:
             if load_exists:
@@ -42,7 +53,13 @@ def get_metadata_json(idno: str, metadata_type: str = None, force: bool = False,
             print(f"Failed to read cache file {cache_path}: {e}")
 
     try:
-        response = httpx.get(f"{METADATA_CATALOG_URL}/api/catalog/json/{idno}")
+        # Add query parameters to the request
+        params = {
+            "include_resources": include_resources,
+        }
+        response = httpx.get(
+            f"{METADATA_CATALOG_URL}/api/catalog/json/{idno}", params=params
+        )
         response.raise_for_status()
         metadata: dict = response.json()
 
@@ -52,9 +69,9 @@ def get_metadata_json(idno: str, metadata_type: str = None, force: bool = False,
             metadata["type"] = "microdata"
 
         if metadata_type:
-            assert (
-                metadata.get("type", None) == metadata_type
-            ), f"The metadata {metadata.get('type')} does not match the requested type: {metadata_type}"
+            assert metadata.get("type", None) == metadata_type, (
+                f"The metadata {metadata.get('type')} does not match the requested type: {metadata_type}"
+            )
 
     except httpx.HTTPStatusError as e:
         raise RuntimeError(f"Failed to fetch metadata for ID {idno}: {e}") from e
@@ -88,17 +105,25 @@ def get_ids_type(result: dict = None) -> dict:
     elif metadata_type == "survey":
         metadata_type = "microdata"
 
-    return dict(id=result.get("id", None), idno=result.get("idno", None), type=metadata_type)
+    return dict(
+        id=result.get("id", None), idno=result.get("idno", None), type=metadata_type
+    )
 
 
-def get_metadata_ids(params: dict = None, search_metadata_func=search_metadata, max_items: int | None = None) -> list:
+def get_metadata_ids(
+    params: dict = None,
+    search_metadata_func=search_metadata,
+    max_items: int | None = None,
+) -> list:
     """
     Retrieve metadata IDs from the metadata catalog based on search parameters.
 
     Paginates through every page unless ``max_items`` is set, in which case pagination
     stops once that many rows have been collected (fewer HTTP calls for smoke tests).
     """
-    default_params = dict(sk="", ps=100, type="timeseries", sort_by="year", sort_order="asc")
+    default_params = dict(
+        sk="", ps=100, type="timeseries", sort_by="year", sort_order="asc"
+    )
     params = {**default_params, **(params or {})}
 
     if max_items is not None and max_items <= 0:

--- a/src/ai4data/discovery/catalog/http.py
+++ b/src/ai4data/discovery/catalog/http.py
@@ -12,7 +12,7 @@ import json
 import httpx
 from tqdm.auto import tqdm
 
-from ..auth import get_catalog_auth_headers
+from ..auth import get_catalog_auth_headers, get_catalog_cookies
 from ..config import METADATA_CATALOG_URL
 from ..paths import get_metadata_cache_path
 
@@ -62,6 +62,7 @@ def get_metadata_json(
             f"{METADATA_CATALOG_URL}/api/catalog/json/{idno}",
             params=params,
             headers=get_catalog_auth_headers(),
+            cookies=get_catalog_cookies(),
         )
         response.raise_for_status()
         metadata: dict = response.json()
@@ -95,6 +96,7 @@ def search_metadata(params: dict = None) -> dict:
         f"{METADATA_CATALOG_URL}/api/catalog/search",
         params=params,
         headers=get_catalog_auth_headers(),
+        cookies=get_catalog_cookies(),
     )
     response.raise_for_status()
     data = response.json().get("result", {})

--- a/src/ai4data/discovery/catalog/http.py
+++ b/src/ai4data/discovery/catalog/http.py
@@ -1,0 +1,126 @@
+"""
+HTTP client for the NADA metadata catalog (search + JSON by idno).
+
+Canonical implementation; ``ai4data.scraper.metadata`` re-exports batch helpers from
+:mod:`ai4data.discovery.catalog.batch` and these functions for backward compatibility.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from tqdm.auto import tqdm
+
+from ..config import METADATA_CATALOG_URL
+from ..paths import get_metadata_cache_path
+
+
+def get_metadata_json(idno: str, metadata_type: str = None, force: bool = False, load_exists: bool = True) -> dict:
+    """
+    Retrieve metadata from a cache or fetch it from the catalog if not cached or if forced.
+
+    Args:
+        idno (str): The ID number of the metadata to retrieve.
+        metadata_type (str, optional): Used for caching. If None, caching is bypassed.
+        force (bool, optional): If True, forces a fresh retrieval.
+        load_exists (bool, optional): If True, load from cache when present.
+
+    Returns:
+        dict: The metadata associated with the given ID number.
+    """
+    cache_path = get_metadata_cache_path(idno, metadata_type) if metadata_type else None
+
+    if cache_path and not force and cache_path.exists():
+        try:
+            if load_exists:
+                with cache_path.open("r") as cache_file:
+                    return json.load(cache_file)
+            else:
+                return None
+        except OSError as e:
+            print(f"Failed to read cache file {cache_path}: {e}")
+
+    try:
+        response = httpx.get(f"{METADATA_CATALOG_URL}/api/catalog/json/{idno}")
+        response.raise_for_status()
+        metadata: dict = response.json()
+
+        if metadata.get("type", None) == "timeseries":
+            metadata["type"] = "indicator"
+        if metadata.get("type", None) == "survey":
+            metadata["type"] = "microdata"
+
+        if metadata_type:
+            assert (
+                metadata.get("type", None) == metadata_type
+            ), f"The metadata {metadata.get('type')} does not match the requested type: {metadata_type}"
+
+    except httpx.HTTPStatusError as e:
+        raise RuntimeError(f"Failed to fetch metadata for ID {idno}: {e}") from e
+
+    if cache_path:
+        try:
+            with cache_path.open("w") as cache_file:
+                json.dump(metadata, cache_file, indent=2)
+        except OSError as e:
+            print(f"Failed to write cache file {cache_path}: {e}")
+
+    return metadata
+
+
+def search_metadata(params: dict = None) -> dict:
+    """Search metadata in the metadata catalog using provided search parameters."""
+    response = httpx.get(f"{METADATA_CATALOG_URL}/api/catalog/search", params=params)
+    response.raise_for_status()
+    data = response.json().get("result", {})
+    return data
+
+
+def get_ids_type(result: dict = None) -> dict:
+    """Extract id, idno, and type from a single catalog search row."""
+    if result is None:
+        return dict(id=None, idno=None, type=None)
+
+    metadata_type = result.get("type", None)
+    if metadata_type == "timeseries":
+        metadata_type = "indicator"
+    elif metadata_type == "survey":
+        metadata_type = "microdata"
+
+    return dict(id=result.get("id", None), idno=result.get("idno", None), type=metadata_type)
+
+
+def get_metadata_ids(params: dict = None, search_metadata_func=search_metadata, max_items: int | None = None) -> list:
+    """
+    Retrieve metadata IDs from the metadata catalog based on search parameters.
+
+    Paginates through every page unless ``max_items`` is set, in which case pagination
+    stops once that many rows have been collected (fewer HTTP calls for smoke tests).
+    """
+    default_params = dict(sk="", ps=100, type="timeseries", sort_by="year", sort_order="asc")
+    params = {**default_params, **(params or {})}
+
+    if max_items is not None and max_items <= 0:
+        return []
+
+    all_metadata_ids: list = []
+
+    params["page"] = 1
+    num_per_page = int(params["ps"])
+
+    data = search_metadata_func(params)
+    all_metadata_ids.extend([get_ids_type(row) for row in data.get("rows", [])])
+    if max_items is not None and len(all_metadata_ids) >= max_items:
+        return all_metadata_ids[:max_items]
+
+    all_pages = int(data.get("found", 0)) // num_per_page + 1
+
+    for page in tqdm(range(2, all_pages + 1)):
+        params["page"] = page
+        data = search_metadata_func(params)
+        all_metadata_ids.extend([get_ids_type(row) for row in data.get("rows", [])])
+        if max_items is not None and len(all_metadata_ids) >= max_items:
+            return all_metadata_ids[:max_items]
+
+    return all_metadata_ids if max_items is None else all_metadata_ids[:max_items]

--- a/src/ai4data/discovery/catalog/http.py
+++ b/src/ai4data/discovery/catalog/http.py
@@ -12,6 +12,7 @@ import json
 import httpx
 from tqdm.auto import tqdm
 
+from ..auth import get_catalog_auth_headers
 from ..config import METADATA_CATALOG_URL
 from ..paths import get_metadata_cache_path
 
@@ -58,7 +59,9 @@ def get_metadata_json(
             "include_resources": include_resources,
         }
         response = httpx.get(
-            f"{METADATA_CATALOG_URL}/api/catalog/json/{idno}", params=params
+            f"{METADATA_CATALOG_URL}/api/catalog/json/{idno}",
+            params=params,
+            headers=get_catalog_auth_headers(),
         )
         response.raise_for_status()
         metadata: dict = response.json()
@@ -88,7 +91,11 @@ def get_metadata_json(
 
 def search_metadata(params: dict = None) -> dict:
     """Search metadata in the metadata catalog using provided search parameters."""
-    response = httpx.get(f"{METADATA_CATALOG_URL}/api/catalog/search", params=params)
+    response = httpx.get(
+        f"{METADATA_CATALOG_URL}/api/catalog/search",
+        params=params,
+        headers=get_catalog_auth_headers(),
+    )
     response.raise_for_status()
     data = response.json().get("result", {})
     return data

--- a/src/ai4data/discovery/catalog/http.py
+++ b/src/ai4data/discovery/catalog/http.py
@@ -73,9 +73,10 @@ def get_metadata_json(
             metadata["type"] = "microdata"
 
         if metadata_type:
-            assert metadata.get("type", None) == metadata_type, (
-                f"The metadata {metadata.get('type')} does not match the requested type: {metadata_type}"
-            )
+            if metadata_type and metadata.get("type", None) != metadata_type:
+                raise ValueError(
+                    f"The metadata type {metadata.get('type')} does not match the requested type: {metadata_type}"
+                )
 
     except httpx.HTTPStatusError as e:
         raise RuntimeError(f"Failed to fetch metadata for ID {idno}: {e}") from e

--- a/src/ai4data/discovery/catalog/langdoc_id.py
+++ b/src/ai4data/discovery/catalog/langdoc_id.py
@@ -1,0 +1,32 @@
+"""
+Stable document id for LangChain langdocs (used when indexing chunks).
+
+Copied from ``ai4data.discovery.metadata.handler`` / ``ai4data.discovery.metadata.utils`` for the
+``ai4data.discovery.catalog`` surface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+from langchain_core.documents import Document as LangchainDocument
+
+from ..metadata.utils import get_idno
+
+
+def create_uuid_from_string(val: str) -> uuid.UUID:
+    hex_string = hashlib.md5(val.encode("UTF-8")).hexdigest()
+    return uuid.UUID(hex=hex_string)
+
+
+def get_langdoc_uuid(doc: LangchainDocument) -> str:
+    """Deterministic id from type, idno, qfield, and page content."""
+    meta = doc.metadata
+    metadata_type = meta["type"]
+    metadata_idno = meta.get("idno") or get_idno(meta, metadata_type)
+    metadata_qfield = meta.get("qfield", "")
+
+    key = f"{metadata_type}__{metadata_idno}__{metadata_qfield}__{doc.page_content}"
+
+    return str(create_uuid_from_string(key))

--- a/src/ai4data/discovery/config.py
+++ b/src/ai4data/discovery/config.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 from dotenv import load_dotenv
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 load_dotenv()
@@ -32,6 +33,24 @@ class EmbeddingTemplatesConfig(BaseSettings):
     )
 
 
+class EmbeddingInferenceConfig(BaseSettings):
+    """HuggingFace embedding model and encode settings for discovery PDF/chunk workflows."""
+
+    model_config = SettingsConfigDict(env_prefix="AI4DATA_EMBEDDING_", case_sensitive=False, extra="ignore")
+
+    model: str = Field(default="avsolatorio/GIST-Embedding-v0")
+    batch_size: int = Field(default=64)
+    device: Optional[str] = Field(default=None)
+    show_progress: bool = Field(default=True)
+
+    @field_validator("show_progress", mode="before")
+    @classmethod
+    def parse_show_progress(cls, v):
+        if isinstance(v, str):
+            return v.lower() == "true"
+        return v
+
+
 class DiscoveryDataConfig(BaseSettings):
     """Root directory for catalog caches (metadata_ids, metadata_cache, document_cache, …)."""
 
@@ -45,7 +64,13 @@ class DiscoveryDataConfig(BaseSettings):
 
 metadata_catalog: MetadataCatalogConfig = MetadataCatalogConfig()
 embedding_templates: EmbeddingTemplatesConfig = EmbeddingTemplatesConfig()
+embedding_inference: EmbeddingInferenceConfig = EmbeddingInferenceConfig()
 discovery_data: DiscoveryDataConfig = DiscoveryDataConfig()
 
 METADATA_CATALOG_URL = metadata_catalog.url
 EMBEDDING_CONTENT_TEMPLATES_PATH = embedding_templates.content_templates_path
+
+EMBEDDING_MODEL = embedding_inference.model
+EMBEDDING_BATCH_SIZE = embedding_inference.batch_size
+EMBEDDING_DEVICE = embedding_inference.device
+EMBEDDING_SHOW_PROGRESS = embedding_inference.show_progress

--- a/src/ai4data/discovery/config.py
+++ b/src/ai4data/discovery/config.py
@@ -29,6 +29,16 @@ class MetadataCatalogConfig(BaseSettings):
             "Hosts not on this list (or the catalog host) never receive the key."
         ),
     )
+    cookies: str | None = Field(
+        default=None,
+        description=(
+            "Optional cookie string sent alongside catalog requests (e.g. "
+            "``ihsn_nada=...; ccsrf=...``). Used for NADA instances that gate PDF downloads "
+            "behind a logged-in session. Host scoping mirrors ``x_api_key`` — the cookies are "
+            "sent unconditionally to catalog endpoints and host-scoped on document download "
+            "URLs (catalog host plus ``x_api_key_hosts``)."
+        ),
+    )
 
 
 class EmbeddingTemplatesConfig(BaseSettings):

--- a/src/ai4data/discovery/config.py
+++ b/src/ai4data/discovery/config.py
@@ -1,0 +1,51 @@
+"""Configuration for discovery workflows (NADA catalog, metadata Jinja templates)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+load_dotenv()
+
+
+class MetadataCatalogConfig(BaseSettings):
+    """NADA / IHSN catalog API and related URLs."""
+
+    model_config = SettingsConfigDict(env_prefix="AI4DATA_METADATA_CATALOG_", case_sensitive=False, extra="forbid")
+
+    url: str = Field(default="https://data-compass.ihsn.org/index.php")
+    thumbnail_url: str = Field(default="https://data-compass.ihsn.org/files/thumbnails/thumbnail-s{db_id}.jpeg")
+    x_api_key: str | None = Field(default=None)
+
+
+class EmbeddingTemplatesConfig(BaseSettings):
+    """Default root directory for per-type Jinja2 templates used when building embedding text from metadata."""
+
+    model_config = SettingsConfigDict(env_prefix="AI4DATA_EMBEDDING_", case_sensitive=False, extra="ignore")
+
+    content_templates_path: Path = Field(
+        default=Path(__file__).resolve().parent / "metadata" / "templates",
+        description="Directory containing subfolders per metadata type (indicator, document, …).",
+    )
+
+
+class DiscoveryDataConfig(BaseSettings):
+    """Root directory for catalog caches (metadata_ids, metadata_cache, document_cache, …)."""
+
+    model_config = SettingsConfigDict(env_prefix="AI4DATA_DISCOVERY_", case_sensitive=False, extra="ignore")
+
+    data_path: Path | None = Field(
+        default=None,
+        description="If set, used as the discovery data root unless init_discovery_paths is called with an explicit path.",
+    )
+
+
+metadata_catalog: MetadataCatalogConfig = MetadataCatalogConfig()
+embedding_templates: EmbeddingTemplatesConfig = EmbeddingTemplatesConfig()
+discovery_data: DiscoveryDataConfig = DiscoveryDataConfig()
+
+METADATA_CATALOG_URL = metadata_catalog.url
+EMBEDDING_CONTENT_TEMPLATES_PATH = embedding_templates.content_templates_path

--- a/src/ai4data/discovery/config.py
+++ b/src/ai4data/discovery/config.py
@@ -20,6 +20,15 @@ class MetadataCatalogConfig(BaseSettings):
     url: str = Field(default="https://data-compass.ihsn.org/index.php")
     thumbnail_url: str = Field(default="https://data-compass.ihsn.org/files/thumbnails/thumbnail-s{db_id}.jpeg")
     x_api_key: str | None = Field(default=None)
+    x_api_key_hosts: str | None = Field(
+        default=None,
+        description=(
+            "Comma-separated list of extra hostnames the ``x-api-key`` header may be sent to "
+            "(e.g. ``training.ihsn.org``). The configured catalog host is always allowed; this "
+            "list is for cases where catalog-resolved download URLs live on a separate subdomain. "
+            "Hosts not on this list (or the catalog host) never receive the key."
+        ),
+    )
 
 
 class EmbeddingTemplatesConfig(BaseSettings):

--- a/src/ai4data/discovery/embeddings.py
+++ b/src/ai4data/discovery/embeddings.py
@@ -1,0 +1,109 @@
+"""Sliding-window HuggingFace embeddings and token splitters for discovery processors.
+
+Uses ``lru_cache`` for process-wide reuse instead of singleton classes. Call
+:func:`ai4data.discovery.wiring.register_discovery_processors` before
+:func:`ai4data.discovery.processors.document.embed_documents` /
+:func:`ai4data.discovery.processors.document.get_doc_reps`.
+"""
+
+from __future__ import annotations
+
+import gc
+from functools import lru_cache
+
+import numpy as np
+from langchain_huggingface.embeddings import HuggingFaceEmbeddings
+from langchain_text_splitters import SentenceTransformersTokenTextSplitter
+
+from .config import embedding_inference
+
+
+def get_device(preferred_device: str | None) -> str:
+    """
+    Resolve device for embedding inference: explicit preference, else cuda, mps, or cpu.
+
+    Imports ``torch`` lazily so importing discovery without embedding stays lighter.
+    """
+    if preferred_device:
+        return preferred_device
+
+    import torch
+
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+
+    return "cpu"
+
+
+@lru_cache(maxsize=1)
+def _cached_huggingface_embeddings(
+    model_name: str,
+    batch_size: int,
+    device_resolved: str,
+    show_progress: bool,
+) -> HuggingFaceEmbeddings:
+    model_kwargs = {"device": device_resolved}
+    encode_kwargs = {"normalize_embeddings": True, "batch_size": batch_size}
+    return HuggingFaceEmbeddings(
+        model_name=model_name,
+        model_kwargs=model_kwargs,
+        encode_kwargs=encode_kwargs,
+        show_progress=show_progress,
+    )
+
+
+def default_embedding_factory() -> HuggingFaceEmbeddings:
+    """Build (cached) HuggingFaceEmbeddings from :data:`embedding_inference` settings."""
+    ei = embedding_inference
+    device = get_device(ei.device)
+    return _cached_huggingface_embeddings(ei.model, ei.batch_size, device, ei.show_progress)
+
+
+@lru_cache(maxsize=1)
+def _cached_sentence_transformers_splitter(model_name: str, chunk_overlap: int) -> SentenceTransformersTokenTextSplitter:
+    return SentenceTransformersTokenTextSplitter(model_name=model_name, chunk_overlap=chunk_overlap)
+
+
+def default_text_splitter_factory() -> SentenceTransformersTokenTextSplitter:
+    """Token-bounded splitter aligned with the embedding model name; ``chunk_overlap`` defaults to 0."""
+    return _cached_sentence_transformers_splitter(embedding_inference.model, 0)
+
+
+def clear_embedding_caches() -> None:
+    """Drop cached embedder/splitter and release GPU memory when CUDA is available."""
+    _cached_huggingface_embeddings.cache_clear()
+    _cached_sentence_transformers_splitter.cache_clear()
+
+    import torch
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    gc.collect()
+
+
+def get_collection_name(embedding_model: HuggingFaceEmbeddings, metadata_type: str | None = None) -> str:
+    """Build a stable collection name from model id and optional metadata type suffix."""
+    collection_name = embedding_model.model_name.replace("/", "__")
+
+    if metadata_type:
+        collection_name = f"{collection_name}__{metadata_type}"
+
+    return collection_name
+
+
+def get_embeddings(
+    docs: list[str],
+    embedding_model: HuggingFaceEmbeddings,
+    *,
+    as_array: bool = True,
+) -> np.ndarray | list:
+    """Embed strings; return a NumPy array when ``as_array`` is True."""
+    embeddings = embedding_model.embed_documents(docs)
+
+    if as_array:
+        return np.array(embeddings)
+
+    return embeddings

--- a/src/ai4data/discovery/metadata/README.md
+++ b/src/ai4data/discovery/metadata/README.md
@@ -1,0 +1,24 @@
+# `ai4data.discovery.metadata`
+
+Metadata loading, LangChain document building, Jinja2 embedding templates, parsers, and search filter facets for NADA-style records.
+
+## Modules
+
+| Module | Role |
+|--------|------|
+| `handler.py` | `MetadataLoader`, per-type `*Metadata` classes, `get_metadata_langdocs`. |
+| `document_fetch.py` | PDF download/cache for document metadata. |
+| `utils.py` | Id helpers, thumbnail URL, cached id lists. |
+| `parsers.py` | Structured parsing helpers per metadata type. |
+| `filters.py` | Pydantic filter facets for search. |
+| `templates/` | Jinja2 templates + `render.py` for embedding text. |
+
+## Legacy shims
+
+`ai4data.metadata` re-exports this package for backward compatibility.
+
+## Related
+
+- Catalog HTTP / batch jobs: `ai4data.discovery.catalog`.
+- PDF loading / chunk helpers used by document metadata: `ai4data.discovery.processors.document` (`load_pdf`, etc.).
+- On-disk paths for metadata id lists, JSON/PDF cache, contextual dimensions: `ai4data.discovery.paths` (Qdrant indexed-id files stay in `ai4data.paths`).

--- a/src/ai4data/discovery/metadata/__init__.py
+++ b/src/ai4data/discovery/metadata/__init__.py
@@ -1,0 +1,1 @@
+"""Metadata handlers, templates, parsers, and filters for discovery workflows."""

--- a/src/ai4data/discovery/metadata/document_fetch.py
+++ b/src/ai4data/discovery/metadata/document_fetch.py
@@ -9,7 +9,7 @@ import logging
 import backoff
 import httpx
 
-from ..auth import get_catalog_auth_headers
+from ..auth import get_catalog_auth_headers, get_catalog_cookies
 from ..paths import get_document_cache_path
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,10 @@ def download_pdf(url: str) -> bytes:
 
     When :envvar:`AI4DATA_METADATA_CATALOG_X_API_KEY` is configured, an ``x-api-key`` header
     is attached for hosts that match the catalog (or are allow-listed via
-    :envvar:`AI4DATA_METADATA_CATALOG_X_API_KEY_HOSTS`). See :mod:`ai4data.discovery.auth`.
+    :envvar:`AI4DATA_METADATA_CATALOG_X_API_KEY_HOSTS`). When
+    :envvar:`AI4DATA_METADATA_CATALOG_COOKIES` is configured, the parsed cookies are
+    attached with the same host scoping (e.g. for NADA instances that gate downloads
+    behind a logged-in session). See :mod:`ai4data.discovery.auth`.
     """
     assert isinstance(url, str), "The url must be a string"
 
@@ -45,6 +48,7 @@ def download_pdf(url: str) -> bytes:
         follow_redirects=True,
         timeout=30,
         headers=get_catalog_auth_headers(url),
+        cookies=get_catalog_cookies(url),
     )
     response.raise_for_status()
 

--- a/src/ai4data/discovery/metadata/document_fetch.py
+++ b/src/ai4data/discovery/metadata/document_fetch.py
@@ -1,0 +1,51 @@
+"""
+Download and cache PDF attachments for document-type metadata (used by :class:`DocumentMetadata`).
+"""
+
+from __future__ import annotations
+
+import backoff
+import httpx
+
+from ..paths import get_document_cache_path
+
+
+@backoff.on_exception(backoff.expo, httpx.HTTPStatusError, max_tries=3)
+def download_pdf(url: str):
+    """
+    Download a pdf file from a url
+    """
+
+    assert isinstance(url, str), "The url must be a string"
+
+    response = httpx.get(url, follow_redirects=True)
+    response.raise_for_status()
+
+    return response.content
+
+
+def cache_download_pdf(url: str, idno: str, metadata_type: str, force: bool = False):
+    """
+    Cache the downloaded pdf file
+    """
+
+    fpath = get_document_cache_path(idno, metadata_type)
+
+    if fpath.exists() and not force:
+        return fpath
+
+    fpath.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        pdf = download_pdf(url)
+    except Exception as e:
+        raise ValueError(f"Error downloading pdf for {idno}: {e}") from e
+
+    try:
+        with open(fpath, "wb") as f:
+            f.write(pdf)
+    except Exception as e:
+        fpath.unlink(missing_ok=True)
+        raise e
+
+    return fpath

--- a/src/ai4data/discovery/metadata/document_fetch.py
+++ b/src/ai4data/discovery/metadata/document_fetch.py
@@ -4,35 +4,89 @@ Download and cache PDF attachments for document-type metadata (used by :class:`D
 
 from __future__ import annotations
 
+import logging
+
 import backoff
 import httpx
 
+from ..auth import get_catalog_auth_headers
 from ..paths import get_document_cache_path
+
+logger = logging.getLogger(__name__)
+
+_PDF_MAGIC = b"%PDF-"
+
+
+class EmptyDownloadError(ValueError):
+    """Raised when the catalog responds with an empty or non-PDF body for a document URL.
+
+    Surfaces the IHSN / NADA case where the server returns ``200 OK`` with ``content-length: 0``
+    and a ``Refresh: 0;url=.../auth/login/...`` header for documents that require login.
+    """
 
 
 @backoff.on_exception(backoff.expo, httpx.HTTPStatusError, max_tries=3)
-def download_pdf(url: str):
-    """
-    Download a pdf file from a url
-    """
+def download_pdf(url: str) -> bytes:
+    """Download a PDF file from a URL and validate that the body is actually a PDF.
 
+    The IHSN / NADA catalog returns ``200 OK`` with an empty body and a ``Refresh`` header
+    pointing at the login page when a document requires authentication. ``raise_for_status``
+    does not catch this, so we explicitly reject empty bodies and payloads that don't start
+    with the ``%PDF-`` magic header.
+
+    When :envvar:`AI4DATA_METADATA_CATALOG_X_API_KEY` is configured, an ``x-api-key`` header
+    is attached for hosts that match the catalog (or are allow-listed via
+    :envvar:`AI4DATA_METADATA_CATALOG_X_API_KEY_HOSTS`). See :mod:`ai4data.discovery.auth`.
+    """
     assert isinstance(url, str), "The url must be a string"
 
-    response = httpx.get(url, follow_redirects=True)
+    response = httpx.get(
+        url,
+        follow_redirects=True,
+        timeout=30,
+        headers=get_catalog_auth_headers(url),
+    )
     response.raise_for_status()
 
-    return response.content
+    content = response.content
+    if not content:
+        refresh = response.headers.get("refresh", "")
+        hint = ""
+        if refresh and ("login" in refresh.lower() or "auth" in refresh.lower()):
+            hint = f" (server responded with login Refresh header: {refresh!r})"
+        raise EmptyDownloadError(f"Empty body from {url}{hint}")
+
+    if not content.startswith(_PDF_MAGIC):
+        preview = content[:64]
+        raise EmptyDownloadError(
+            f"Response from {url} is not a PDF (first 64 bytes: {preview!r})"
+        )
+
+    return content
 
 
 def cache_download_pdf(url: str, idno: str, metadata_type: str, force: bool = False):
     """
-    Cache the downloaded pdf file
+    Cache the downloaded pdf file.
+
+    A 0-byte file left over from a previous failed download (e.g. an auth-gated URL that
+    returned ``200 OK`` with an empty body) is treated as a cache miss and retried, so we
+    don't permanently poison the cache.
     """
 
     fpath = get_document_cache_path(idno, metadata_type)
 
     if fpath.exists() and not force:
-        return fpath
+        try:
+            existing_size = fpath.stat().st_size
+        except OSError:
+            existing_size = 0
+        if existing_size > 0:
+            return fpath
+        logger.warning(
+            "Discarding 0-byte cached PDF before re-downloading: %s", fpath
+        )
+        fpath.unlink(missing_ok=True)
 
     fpath.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/ai4data/discovery/metadata/filters.py
+++ b/src/ai4data/discovery/metadata/filters.py
@@ -71,7 +71,7 @@ class DocumentFilterFacets(FilterFacets):
     type: str = "document"
     document_type: str = None
     date_published: str = None
-    date_created: str = None
+    date_created: str | None = None
     authors: list[str] = None
 
     @staticmethod

--- a/src/ai4data/discovery/metadata/filters.py
+++ b/src/ai4data/discovery/metadata/filters.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+# This defines the facets for each metadata type. The facets are used to filter the metadata in the search.
+from pydantic import BaseModel
+
+from .parsers import DocumentParser, GeospatialParser, IndicatorParser, MicrodataParser
+from .utils import create_uuid_from_string
+
+
+class FilterFacets(BaseModel):
+    type: str
+    idno: str
+    idno_uuid: str | None = None
+
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    year_start: int | None = None
+    year_end: int | None = None
+    years: list[int] | None = None
+
+    geographies: list[str] | None = None
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self.idno_uuid = str(create_uuid_from_string(self.idno))
+
+    @staticmethod
+    def from_metadata(metadata: dict):
+        """
+        Create a FilterFacets object from metadata.
+
+        Args:
+            metadata (dict): The metadata.
+        """
+        raise NotImplementedError()
+
+
+class IndicatorFilterFacets(FilterFacets):
+    type: str = "indicator"
+    periodicity: str = None
+    source: list[str] = None
+
+    @staticmethod
+    def from_metadata(metadata: dict) -> IndicatorFilterFacets:
+        """
+        Create a FilterFacets object from metadata.
+
+        Args:
+            metadata (dict): The metadata.
+        """
+        parser = IndicatorParser()
+        idno = parser.parse_idno(metadata)
+        periods = parser.parse_periods(metadata, out_format="details")
+        geographies = parser.parse_geographies(metadata)
+        source = parser.parse_source(metadata)
+        periodicity = parser.parse_periodicity(metadata)
+
+        return IndicatorFilterFacets(
+            idno=idno,
+            year_start=periods.get("year_start"),
+            year_end=periods.get("year_end"),
+            years=periods.get("years"),
+            geographies=geographies,
+            source=source,
+            periodicity=periodicity,
+        )
+
+
+class DocumentFilterFacets(FilterFacets):
+    type: str = "document"
+    document_type: str = None
+    date_published: str = None
+    date_created: str = None
+    authors: list[str] = None
+
+    @staticmethod
+    def from_metadata(metadata: dict) -> DocumentFilterFacets:
+        """
+        Create a FilterFacets object from metadata.
+
+        Args:
+            metadata (dict): The metadata.
+        """
+        parser = DocumentParser()
+        idno = parser.parse_idno(metadata)
+        date_published = parser.parse_date_published(metadata)
+        date_created = parser.parse_date_created(metadata)
+        authors = parser.parse_authors(metadata)
+        document_type = parser.parse_document_type(metadata)
+
+        periods = parser.parse_periods(metadata, out_format="details")
+        geographies = parser.parse_geographies(metadata)
+
+        return DocumentFilterFacets(
+            idno=idno,
+            year_start=periods.get("year_start"),
+            year_end=periods.get("year_end"),
+            years=periods.get("years"),
+            geographies=geographies,
+            date_published=date_published,
+            date_created=date_created,
+            authors=authors,
+            document_type=document_type,
+        )
+
+
+class GeospatialFilterFacets(FilterFacets):
+    type: str = "geospatial"
+    source: list[str] = None
+
+    @staticmethod
+    def from_metadata(metadata: dict) -> GeospatialFilterFacets:
+        """
+        Create a FilterFacets object from metadata.
+
+        Args:
+            metadata (dict): The metadata.
+        """
+        parser = GeospatialParser()
+        idno = parser.parse_idno(metadata)
+        geographies = parser.parse_geographies(metadata)
+        source = parser.parse_source(metadata)
+        periods = parser.parse_periods(metadata, out_format="details")
+
+        return GeospatialFilterFacets(
+            idno=idno,
+            year_start=periods.get("year_start"),
+            year_end=periods.get("year_end"),
+            years=periods.get("years"),
+            geographies=geographies,
+            source=source,
+        )
+
+
+class MicrodataFilterFacets(FilterFacets):
+    type: str = "microdata"
+    source: list[str] | None = None
+
+    @staticmethod
+    def from_metadata(metadata: dict) -> MicrodataFilterFacets:
+        """
+        Create a FilterFacets object from metadata.
+
+        Args:
+            metadata (dict): The metadata.
+        """
+
+        parser = MicrodataParser()
+        idno = parser.parse_idno(metadata)
+        geographies = parser.parse_geographies(metadata)
+        source = parser.parse_source(metadata)
+        periods = parser.parse_periods(metadata, out_format="details")
+
+        return MicrodataFilterFacets(
+            idno=idno,
+            year_start=periods.get("year_start"),
+            year_end=periods.get("year_end"),
+            years=periods.get("years"),
+            geographies=geographies,
+            source=source,
+        )
+
+
+def get_filter_facets(metadata: dict) -> FilterFacets:
+    """
+    Get the filter facets for the metadata.
+
+    Args:
+        metadata (dict): The metadata.
+
+    Returns:
+        FilterFacets: The filter facets.
+    """
+    metadata_type = metadata.get("type")
+
+    if metadata_type == "indicator":
+        return IndicatorFilterFacets.from_metadata(metadata)
+    elif metadata_type == "document":
+        return DocumentFilterFacets.from_metadata(metadata)
+    elif metadata_type == "geospatial":
+        return GeospatialFilterFacets.from_metadata(metadata)
+    elif metadata_type == "microdata":
+        return MicrodataFilterFacets.from_metadata(metadata)
+    else:
+        raise ValueError(f"Invalid metadata type: {metadata_type}")
+
+
+# filter_facets = dict(
+#     indicator=[
+#         dict(
+#             name="time_coverage",
+#             title="Time Coverage",
+#             path="series_description.time_periods",
+#         ),
+#         dict(
+#             name="geographic_coverage",
+#             title="Geographic Coverage",
+#             path="series_description.ref_country"
+#         ),
+#         dict(
+#             name="periodicity",
+#             title="Periodicity",
+#             path="series_description.periodicity"
+#         ),
+#         dict(
+#             name="authoring_entity",
+#             title="Source",
+#             path="series_description.authoring_entity"
+#         ),
+#     ],
+#     document=[
+#         dict(
+#             name="publication_date",
+#             title="Publication Date",
+#             path="document_description.date_published",
+#         ),
+#         dict(path="document_description.subject"),
+#         dict(path="document_description.country"),
+#     ],
+#     microdata=[
+#         dict(path="study_desc.subject"),
+#         dict(path="study_desc.country"),
+#     ],
+#     geospatial=[
+#         dict(path="description.subject"),
+#         dict(path="description.country"),
+#     ],
+# )

--- a/src/ai4data/discovery/metadata/handler.py
+++ b/src/ai4data/discovery/metadata/handler.py
@@ -9,12 +9,23 @@ from ..catalog.langdoc_id import get_langdoc_uuid  # noqa: F401 — re-exported 
 from ..paths import get_contextualized_dimensions_path
 from ..processors.document import load_pdf
 from .document_fetch import cache_download_pdf
-from .filters import DocumentFilterFacets, GeospatialFilterFacets, IndicatorFilterFacets, MicrodataFilterFacets
+from .filters import (
+    DocumentFilterFacets,
+    GeospatialFilterFacets,
+    IndicatorFilterFacets,
+    MicrodataFilterFacets,
+)
 from .templates.render import get_searchpath, render_embedding_content
 
 
 class Metadata(ABC):
-    def __init__(self, metadata: dict, collection_fields: list, metadata_type: str = None, searchpath: str = None):
+    def __init__(
+        self,
+        metadata: dict,
+        collection_fields: list,
+        metadata_type: str = None,
+        searchpath: str = None,
+    ):
         """
         Initialize the Metadata handler.
 
@@ -31,7 +42,9 @@ class Metadata(ABC):
         self.collection_fields = collection_fields
 
         path = Path(get_searchpath(self.type, searchpath))
-        self.available_fields = set(i.stem.split("__")[1] for i in path.glob("*.jinja2"))
+        self.available_fields = set(
+            i.stem.split("__")[1] for i in path.glob("*.jinja2")
+        )
 
     @property
     def metadata(self) -> dict:
@@ -84,7 +97,9 @@ class Metadata(ABC):
         if not page_content:
             return None
 
-        return LangchainDocument(page_content=page_content, metadata={"qfield": field, **self.payload})
+        return LangchainDocument(
+            page_content=page_content, metadata={"qfield": field, **self.payload}
+        )
 
     def embedding_content(self, field) -> str:
         """
@@ -93,9 +108,13 @@ class Metadata(ABC):
         Returns:
             str: The content to be used for embedding.
         """
-        assert field in self.collection_fields, f"Field {field} not in collection fields {self.collection_fields}"
+        assert field in self.collection_fields, (
+            f"Field {field} not in collection fields {self.collection_fields}"
+        )
 
-        embedding_content = render_embedding_content(self.metadata, self.type, field, searchpath=self.searchpath)
+        embedding_content = render_embedding_content(
+            self.metadata, self.type, field, searchpath=self.searchpath
+        )
 
         return embedding_content.strip()
 
@@ -116,7 +135,11 @@ class IndicatorMetadata(Metadata):
     def __init__(self, **kwargs):
         super().__init__(
             metadata_type="indicator",
-            collection_fields=["name", "definition", "dimensions"],  # , "relevance", "keywords"],
+            collection_fields=[
+                "name",
+                "definition",
+                "dimensions",
+            ],  # , "relevance", "keywords"],
             **kwargs,
         )
 
@@ -154,14 +177,22 @@ class IndicatorMetadata(Metadata):
         langdocs.append(
             LangchainDocument(
                 page_content=data["dimension_info"],
-                metadata={"qfield": "dimensions", "doc_meta": {"type": "actual"}, **self.payload},
+                metadata={
+                    "qfield": "dimensions",
+                    "doc_meta": {"type": "actual"},
+                    **self.payload,
+                },
             )
         )
 
         langdocs.append(
             LangchainDocument(
                 page_content=data["output"],
-                metadata={"qfield": "dimensions", "doc_meta": {"type": "contextual"}, **self.payload},
+                metadata={
+                    "qfield": "dimensions",
+                    "doc_meta": {"type": "contextual"},
+                    **self.payload,
+                },
             )
         )
 
@@ -212,7 +243,13 @@ class DocumentMetadata(Metadata):
     def __init__(self, **kwargs):
         super().__init__(
             metadata_type="document",
-            collection_fields=["title", "sub_title", "abstract", "passages", "keywords"],
+            collection_fields=[
+                "title",
+                "sub_title",
+                "abstract",
+                "passages",
+                "keywords",
+            ],
             **kwargs,
         )
 
@@ -234,7 +271,23 @@ class DocumentMetadata(Metadata):
         Returns:
             list: A list of LangChain documents.
         """
+
+        # Check if the document url is in the metadata
         url = self.metadata.get("document_description", {}).get("url", None)
+
+        # If external resources are available, prefer that over the document url
+        external_resources = self.metadata.get("external_resources", None)
+        if external_resources:
+            for resource in external_resources:
+                if (
+                    resource.get("dcformat", None) == "application/pdf"
+                    and resource.get("is_url", 1) == 0
+                ):
+                    url = resource.get("url", None)
+                    # We only consider the first pdf url we find
+                    # TODO: We should consider all pdf urls and use them all for the document
+                    break
+
         docs = []
 
         if url:
@@ -245,7 +298,8 @@ class DocumentMetadata(Metadata):
 
         return [
             LangchainDocument(
-                page_content=doc.page_content, metadata={"qfield": field, "doc_meta": doc.metadata, **self.payload}
+                page_content=doc.page_content,
+                metadata={"qfield": field, "doc_meta": doc.metadata, **self.payload},
             )
             for doc in docs
         ]
@@ -281,7 +335,11 @@ class DocumentMetadata(Metadata):
 
 class GeospatialMetadata(Metadata):
     def __init__(self, **kwargs):
-        super().__init__(metadata_type="geospatial", collection_fields=["title", "abstract"], **kwargs)
+        super().__init__(
+            metadata_type="geospatial",
+            collection_fields=["title", "abstract"],
+            **kwargs,
+        )
 
     def get_payload(self) -> dict:
         """
@@ -362,7 +420,9 @@ class MicrodataMetadata(Metadata):
 
 
 class MetadataLoader:
-    def __init__(self, idno: str, metadata_type: str, force: bool = False, searchpath: str = None):
+    def __init__(
+        self, idno: str, metadata_type: str, force: bool = False, searchpath: str = None
+    ):
         """
         Initialize the MetadataLoader.
 
@@ -400,7 +460,9 @@ class MetadataLoader:
         elif self.type == "document":
             return DocumentMetadata(metadata=self.metadata, searchpath=self.searchpath)
         elif self.type == "geospatial":
-            return GeospatialMetadata(metadata=self.metadata, searchpath=self.searchpath)
+            return GeospatialMetadata(
+                metadata=self.metadata, searchpath=self.searchpath
+            )
         elif self.type == "microdata":
             return MicrodataMetadata(metadata=self.metadata, searchpath=self.searchpath)
         else:
@@ -422,6 +484,8 @@ def get_metadata_langdocs(
     Returns:
         list: A list of LangChain documents.
     """
-    loader = MetadataLoader(idno=idno, metadata_type=metadata_type, force=force, searchpath=searchpath)
+    loader = MetadataLoader(
+        idno=idno, metadata_type=metadata_type, force=force, searchpath=searchpath
+    )
     metadata_handler = loader.get_metadata_handler()
     return metadata_handler.get_langdocs()

--- a/src/ai4data/discovery/metadata/handler.py
+++ b/src/ai4data/discovery/metadata/handler.py
@@ -1,0 +1,427 @@
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from langchain_core.documents import Document as LangchainDocument
+
+from ..catalog.http import get_metadata_json
+from ..catalog.langdoc_id import get_langdoc_uuid  # noqa: F401 — re-exported for callers
+from ..paths import get_contextualized_dimensions_path
+from ..processors.document import load_pdf
+from .document_fetch import cache_download_pdf
+from .filters import DocumentFilterFacets, GeospatialFilterFacets, IndicatorFilterFacets, MicrodataFilterFacets
+from .templates.render import get_searchpath, render_embedding_content
+
+
+class Metadata(ABC):
+    def __init__(self, metadata: dict, collection_fields: list, metadata_type: str = None, searchpath: str = None):
+        """
+        Initialize the Metadata handler.
+
+        Args:
+            metadata (dict): The metadata dictionary.
+            collection_fields (list): Fields to be used for multiple collection indexing for a metadata type, (e.g., 'title', 'abstract', 'passages').
+            metadata_type (str, optional): Type of metadata (e.g., 'document', 'indicator').
+            searchpath (str, optional): Path used for searching or rendering templates. Defaults to None.
+        """
+        self._metadata = metadata
+        self._payload = None
+        self.type = metadata_type
+        self.searchpath = searchpath
+        self.collection_fields = collection_fields
+
+        path = Path(get_searchpath(self.type, searchpath))
+        self.available_fields = set(i.stem.split("__")[1] for i in path.glob("*.jinja2"))
+
+    @property
+    def metadata(self) -> dict:
+        """
+        Retrieve the metadata.
+
+        Returns:
+            dict: The metadata.
+        """
+        return self._metadata
+
+    @property
+    def payload(self) -> dict:
+        """
+        Retrieve the payload.
+
+        Returns:
+            dict: The payload.
+        """
+        if self._payload is None:
+            self._payload = self.get_payload()
+        return self._payload
+
+    @abstractmethod
+    def get_payload(self) -> dict:
+        """
+        Retrieve the payload for the metadata that will be used for filtering.
+
+        Returns:
+            dict: The payload.
+        """
+        raise NotImplementedError("Subclasses must implement the get_payload method.")
+
+    def build_metadata_langdoc(self, field: str) -> LangchainDocument:
+        """
+        Build a LangChain document for a specific field of the metadata.
+
+        Args:
+            field (str): The field to build the LangChain document for.
+
+        Returns:
+            LangchainDocument: A LangChain document.
+        """
+        try:
+            page_content = self.embedding_content(field)
+        except Exception as e:
+            print(f"Error building metadata langdoc for {field}: {e}")
+            return
+
+        if not page_content:
+            return None
+
+        return LangchainDocument(page_content=page_content, metadata={"qfield": field, **self.payload})
+
+    def embedding_content(self, field) -> str:
+        """
+        Generate the embedding content from the metadata for a specific field.
+
+        Returns:
+            str: The content to be used for embedding.
+        """
+        assert field in self.collection_fields, f"Field {field} not in collection fields {self.collection_fields}"
+
+        embedding_content = render_embedding_content(self.metadata, self.type, field, searchpath=self.searchpath)
+
+        return embedding_content.strip()
+
+    @abstractmethod
+    def get_langdocs(self) -> list[LangchainDocument]:
+        """
+        Retrieve the LangChain documents for the metadata.
+
+        This method must be implemented by subclasses to return content that will be indexed based on the metadata type.
+
+        Returns:
+            list: A list of LangChain documents.
+        """
+        raise NotImplementedError("Subclasses must implement the get_langdocs method.")
+
+
+class IndicatorMetadata(Metadata):
+    def __init__(self, **kwargs):
+        super().__init__(
+            metadata_type="indicator",
+            collection_fields=["name", "definition", "dimensions"],  # , "relevance", "keywords"],
+            **kwargs,
+        )
+
+    def get_payload(self) -> dict:
+        """
+        Retrieve the payload for the indicator metadata that will be used for filtering.
+
+        Returns:
+            dict: The payload.
+        """
+
+        payload = IndicatorFilterFacets.from_metadata(self.metadata)
+        return payload.model_dump()
+
+    def get_dimensions_langdocs(self) -> list[LangchainDocument]:
+        """
+        Retrieve the LangChain documents for the indicator dimensions. This uses the contextual reformulation model to generate a contextual description based on the dimensions.
+
+        The script `scripts/synthetic_data/indicator/generate_contextual_dimensions.py` is used to generate the contextual dimensions.
+
+        The output is stored in the `DATA_DIR/contextual_dimensions` which comes from the output of the script. The raw output is from `scripts/synthetic_data/output/indicator/generate_contextual_dimensions`.
+
+        Returns:
+            list: A list of LangChain documents.
+        """
+        langdocs = []
+
+        raw_path = get_contextualized_dimensions_path(self.metadata["idno"], raw=True)
+        if not raw_path.exists():
+            return langdocs
+
+        with open(raw_path) as f:
+            data = json.load(f)
+
+        langdocs.append(
+            LangchainDocument(
+                page_content=data["dimension_info"],
+                metadata={"qfield": "dimensions", "doc_meta": {"type": "actual"}, **self.payload},
+            )
+        )
+
+        langdocs.append(
+            LangchainDocument(
+                page_content=data["output"],
+                metadata={"qfield": "dimensions", "doc_meta": {"type": "contextual"}, **self.payload},
+            )
+        )
+
+        return langdocs
+
+    def get_langdocs(self) -> list[LangchainDocument]:
+        """
+        Retrieve the LangChain documents for the indicator metadata.
+
+        Returns:
+            list: A list of LangChain documents.
+        """
+
+        langdocs = []
+
+        # Add the metadata document
+        for field in self.collection_fields:
+            if field == "dimensions":
+                langdocs.extend(self.get_dimensions_langdocs())
+                continue
+
+            if field not in self.available_fields:
+                continue
+
+            field_doc = self.build_metadata_langdoc(field)
+
+            if field_doc is not None:
+                langdocs.append(field_doc)
+
+        return langdocs
+
+
+class DocumentMetadata(Metadata):
+    """
+    Ideas for how we should work with documents:
+
+    - Include the title in generating the embeddings,
+        - If the title is retrieved as the most relevant for a query,
+        - we do not use it directly as the input to an LLM. Instead, we use the title to retrieve the document.
+        - We then use the most relevant section of the document as the input to the LLM together with the title.
+
+    - Contents considered for the embeddings:
+        - Title + Abstract
+        - Keywords
+        - Sections of the document
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            metadata_type="document",
+            collection_fields=["title", "sub_title", "abstract", "passages", "keywords"],
+            **kwargs,
+        )
+
+    def get_payload(self) -> dict:
+        """
+        Retrieve the payload for the document metadata that will be used for filtering.
+
+        Returns:
+            dict: The payload.
+        """
+
+        payload = DocumentFilterFacets.from_metadata(self.metadata)
+        return payload.model_dump()
+
+    def get_doc_langdocs(self, field: str = "passages") -> list[LangchainDocument]:
+        """
+        Retrieve the LangChain documents for the document metadata.
+
+        Returns:
+            list: A list of LangChain documents.
+        """
+        url = self.metadata.get("document_description", {}).get("url", None)
+        docs = []
+
+        if url:
+            # Download the document pdf.
+            # We only consider pdfs for now.
+            pdf_path = cache_download_pdf(url, self.metadata.get("idno"), self.type)
+            docs = load_pdf(pdf_path)
+
+        return [
+            LangchainDocument(
+                page_content=doc.page_content, metadata={"qfield": field, "doc_meta": doc.metadata, **self.payload}
+            )
+            for doc in docs
+        ]
+
+    def get_langdocs(self) -> list[LangchainDocument]:
+        """
+        Retrieve the LangChain documents for the document metadata.
+
+        Returns:
+            list: A list of LangChain documents.
+        """
+        langdocs = []
+
+        # Add the metadata document
+        for field in self.collection_fields:
+            if field == "passages":
+                continue
+
+            if field not in self.available_fields:
+                continue
+
+            field_doc = self.build_metadata_langdoc(field)
+
+            if field_doc is not None:
+                langdocs.append(field_doc)
+
+        # Get the contents from the document itself
+        doc_contents = self.get_doc_langdocs()
+        langdocs.extend(doc_contents)
+
+        return langdocs
+
+
+class GeospatialMetadata(Metadata):
+    def __init__(self, **kwargs):
+        super().__init__(metadata_type="geospatial", collection_fields=["title", "abstract"], **kwargs)
+
+    def get_payload(self) -> dict:
+        """
+        Retrieve the payload for the geospatial metadata that will be used for filtering.
+
+        Returns:
+            dict: The payload.
+        """
+
+        payload = GeospatialFilterFacets.from_metadata(self.metadata)
+        return payload.model_dump()
+
+    def get_langdocs(self) -> list[LangchainDocument]:
+        """
+        Retrieve the LangChain documents for the geospatial metadata.
+
+        Returns:
+            list: A list of LangChain documents.
+        """
+        langdocs = []
+
+        # Add the metadata document
+        for field in self.collection_fields:
+            if field not in self.available_fields:
+                continue
+
+            field_doc = self.build_metadata_langdoc(field)
+
+            if field_doc is not None:
+                langdocs.append(field_doc)
+
+        return langdocs
+
+
+class MicrodataMetadata(Metadata):
+    def __init__(self, **kwargs):
+        super().__init__(
+            metadata_type="microdata",
+            collection_fields=[
+                "title",
+                "sub_title",
+                "abstract",
+            ],  # "variable_groups", file_description", "sample_design", "sample_frame"],
+            **kwargs,
+        )
+
+    def get_payload(self) -> dict:
+        """
+        Retrieve the payload for the microdata metadata that will be used for filtering.
+
+        Returns:
+            dict: The payload.
+        """
+
+        payload = MicrodataFilterFacets.from_metadata(self.metadata)
+        return payload.model_dump()
+
+    def get_langdocs(self) -> list[LangchainDocument]:
+        """
+        Retrieve the LangChain documents for the microdata metadata.
+
+        Returns:
+            list: A list of LangChain documents.
+        """
+        langdocs = []
+
+        # Add the metadata document
+        for field in self.collection_fields:
+            if field not in self.available_fields:
+                continue
+
+            field_doc = self.build_metadata_langdoc(field)
+
+            if field_doc is not None:
+                langdocs.append(field_doc)
+
+        return langdocs
+
+
+class MetadataLoader:
+    def __init__(self, idno: str, metadata_type: str, force: bool = False, searchpath: str = None):
+        """
+        Initialize the MetadataLoader.
+
+        Args:
+            idno (str): The identifier number for fetching metadata.
+            metadata_type (str): Type of metadata (e.g., 'document', 'indicator').
+            force (bool, optional): If True, forces fetching the metadata from the catalog even if cached. Defaults to False.
+            searchpath (str, optional): Path used for searching or rendering templates. Defaults to None.
+        """
+        self.idno = idno
+        self.type = metadata_type
+        self.force = force
+        self.searchpath = searchpath
+        self.metadata = self.load_metadata()
+        self.metadata["idno"] = self.idno
+
+    def load_metadata(self) -> dict:
+        """
+        Load the metadata using the idno and metadata type.
+
+        Returns:
+            dict: The loaded metadata.
+        """
+        return get_metadata_json(self.idno, self.type, force=self.force)
+
+    def get_metadata_handler(self) -> Metadata:
+        """
+        Get the appropriate Metadata handler class based on the type of metadata.
+
+        Returns:
+            Metadata: An instance of the appropriate Metadata subclass.
+        """
+        if self.type == "indicator":
+            return IndicatorMetadata(metadata=self.metadata, searchpath=self.searchpath)
+        elif self.type == "document":
+            return DocumentMetadata(metadata=self.metadata, searchpath=self.searchpath)
+        elif self.type == "geospatial":
+            return GeospatialMetadata(metadata=self.metadata, searchpath=self.searchpath)
+        elif self.type == "microdata":
+            return MicrodataMetadata(metadata=self.metadata, searchpath=self.searchpath)
+        else:
+            raise ValueError(f"Type {self.type} not supported")
+
+
+def get_metadata_langdocs(
+    idno: str, metadata_type: str, force: bool = False, searchpath: str = None
+) -> list[LangchainDocument]:
+    """
+    Get the metadata documents for the given idno and metadata type.
+
+    Args:
+        idno (str): The identifier number.
+        metadata_type (str): The type of metadata (e.g., 'indicator', 'document').
+        force (bool, optional): If True, forces fetching the metadata from the catalog even if cached. Defaults to False.
+        searchpath (str, optional): Path used for searching or rendering templates. Defaults to None.
+
+    Returns:
+        list: A list of LangChain documents.
+    """
+    loader = MetadataLoader(idno=idno, metadata_type=metadata_type, force=force, searchpath=searchpath)
+    metadata_handler = loader.get_metadata_handler()
+    return metadata_handler.get_langdocs()

--- a/src/ai4data/discovery/metadata/handler.py
+++ b/src/ai4data/discovery/metadata/handler.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -16,6 +17,8 @@ from .filters import (
     MicrodataFilterFacets,
 )
 from .templates.render import get_searchpath, render_embedding_content
+
+logger = logging.getLogger(__name__)
 
 
 class Metadata(ABC):
@@ -330,8 +333,19 @@ class DocumentMetadata(Metadata):
             if field_doc is not None:
                 langdocs.append(field_doc)
 
-        # Get the contents from the document itself
-        doc_contents = self.get_doc_langdocs()
+        # Get the contents from the document itself. PDF retrieval can fail (e.g. auth-gated
+        # URLs returning 200 OK with an empty body, transient HTTP errors, malformed PDFs).
+        # Don't let that drop the metadata-only langdocs (title / abstract / keywords) — they
+        # are still useful for search.
+        try:
+            doc_contents = self.get_doc_langdocs()
+        except Exception as exc:
+            logger.warning(
+                "Could not fetch PDF contents for document %s: %s",
+                self.metadata.get("idno"),
+                exc,
+            )
+            doc_contents = []
         langdocs.extend(doc_contents)
 
         return langdocs

--- a/src/ai4data/discovery/metadata/handler.py
+++ b/src/ai4data/discovery/metadata/handler.py
@@ -421,7 +421,12 @@ class MicrodataMetadata(Metadata):
 
 class MetadataLoader:
     def __init__(
-        self, idno: str, metadata_type: str, force: bool = False, searchpath: str = None
+        self,
+        idno: str,
+        metadata_type: str,
+        force: bool = False,
+        searchpath: str = None,
+        include_resources: bool = False,
     ):
         """
         Initialize the MetadataLoader.
@@ -431,11 +436,13 @@ class MetadataLoader:
             metadata_type (str): Type of metadata (e.g., 'document', 'indicator').
             force (bool, optional): If True, forces fetching the metadata from the catalog even if cached. Defaults to False.
             searchpath (str, optional): Path used for searching or rendering templates. Defaults to None.
+            include_resources (bool, optional): If True, include the resources in the metadata. Defaults to False.
         """
         self.idno = idno
         self.type = metadata_type
         self.force = force
         self.searchpath = searchpath
+        self.include_resources = include_resources
         self.metadata = self.load_metadata()
         self.metadata["idno"] = self.idno
 
@@ -446,7 +453,12 @@ class MetadataLoader:
         Returns:
             dict: The loaded metadata.
         """
-        return get_metadata_json(self.idno, self.type, force=self.force)
+        return get_metadata_json(
+            self.idno,
+            self.type,
+            force=self.force,
+            include_resources=self.include_resources,
+        )
 
     def get_metadata_handler(self) -> Metadata:
         """

--- a/src/ai4data/discovery/metadata/handler.py
+++ b/src/ai4data/discovery/metadata/handler.py
@@ -279,9 +279,13 @@ class DocumentMetadata(Metadata):
         external_resources = self.metadata.get("external_resources", None)
         if external_resources:
             for resource in external_resources:
+                is_url = str(resource.get("is_url", "1"))
+                assert is_url in ("0", "1"), (
+                    f'Invalid `is_url` value: {is_url}, expected "0" or "1"'
+                )
                 if (
                     resource.get("dcformat", None) == "application/pdf"
-                    and resource.get("is_url", 1) == 0
+                    and is_url == "0"
                 ):
                     url = resource.get("url", None)
                     # We only consider the first pdf url we find
@@ -482,7 +486,11 @@ class MetadataLoader:
 
 
 def get_metadata_langdocs(
-    idno: str, metadata_type: str, force: bool = False, searchpath: str = None
+    idno: str,
+    metadata_type: str,
+    force: bool = False,
+    searchpath: str = None,
+    include_resources: bool = False,
 ) -> list[LangchainDocument]:
     """
     Get the metadata documents for the given idno and metadata type.
@@ -492,12 +500,17 @@ def get_metadata_langdocs(
         metadata_type (str): The type of metadata (e.g., 'indicator', 'document').
         force (bool, optional): If True, forces fetching the metadata from the catalog even if cached. Defaults to False.
         searchpath (str, optional): Path used for searching or rendering templates. Defaults to None.
+        include_resources (bool, optional): If True, include the resources in the metadata. Defaults to False.
 
     Returns:
         list: A list of LangChain documents.
     """
     loader = MetadataLoader(
-        idno=idno, metadata_type=metadata_type, force=force, searchpath=searchpath
+        idno=idno,
+        metadata_type=metadata_type,
+        force=force,
+        searchpath=searchpath,
+        include_resources=include_resources,
     )
     metadata_handler = loader.get_metadata_handler()
     return metadata_handler.get_langdocs()

--- a/src/ai4data/discovery/metadata/parsers.py
+++ b/src/ai4data/discovery/metadata/parsers.py
@@ -40,7 +40,9 @@ class Parser:
 
         return get_idno(metadata, self.metadata_type)
 
-    def parse_geographies(self, geographies: list[dict], source: str = "name") -> list[str]:
+    def parse_geographies(
+        self, geographies: list[dict], source: str = "name"
+    ) -> list[str]:
         """
         Parse the geographies formated as `[{"name": <geo_name>, "code": <geo_code>}, ...]` into a list of strings.
 
@@ -52,12 +54,16 @@ class Parser:
             list[str]: The parsed geographies.
         """
         geographic_coverage = filter(lambda gc: gc.get(source), geographies)
-        geographic_coverage = sorted(set([gc.get(source) for gc in geographic_coverage]))
+        geographic_coverage = sorted(
+            set([gc.get(source) for gc in geographic_coverage])
+        )
         geographic_coverage = None if not geographic_coverage else geographic_coverage
 
         return geographic_coverage
 
-    def parse_periods(self, periods: list[dict], out_format: str = "summary") -> str | dict:
+    def parse_periods(
+        self, periods: list[dict], out_format: str = "summary"
+    ) -> str | dict:
         """
         Parse the periods into a single string.
 
@@ -107,7 +113,9 @@ class Parser:
             )
             return details
 
-    def parse_doi_from_identifiers(self, identifiers: list[dict[str, str]] | dict[str, str]) -> str | None:
+    def parse_doi_from_identifiers(
+        self, identifiers: list[dict[str, str]] | dict[str, str]
+    ) -> str | None:
         """
         Parse the DOI from the metadata identifiers.
 
@@ -117,7 +125,18 @@ class Parser:
         Returns:
             str: The parsed DOI.
         """
+        if not identifiers:
+            return None
+
         doi: str | None = None
+
+        # Use recursive approach to parse the DOI from a list of identifiers
+        if isinstance(identifiers, list):
+            for identifier in identifiers:
+                doi = self.parse_doi_from_identifiers(identifier)
+                if doi:
+                    return doi
+            return None
 
         for identifier in identifiers:
             if identifier.get("type", "").lower().strip() == "doi":
@@ -252,7 +271,9 @@ class IndicatorParser(Parser):
         """
         series: dict = self.get_series(metadata)
 
-        definition: str | None = series.get("definition_long", series.get("definition_short", None))
+        definition: str | None = series.get(
+            "definition_long", series.get("definition_short", None)
+        )
 
         return definition
 
@@ -268,13 +289,17 @@ class IndicatorParser(Parser):
         """
         series: dict = self.get_series(metadata)
 
-        dimensions: list[dict[str, str | list[dict[str, str | int]]]] = series.get("dimensions", [])
+        dimensions: list[dict[str, str | list[dict[str, str | int]]]] = series.get(
+            "dimensions", []
+        )
 
         dimensions = [dim.get("label") for dim in dimensions if dim.get("label")]
 
         return sorted(dimensions)
 
-    def parse_dimensions_for_llm(self, metadata: dict, add_indicator_info: bool = True, limit: int = 10) -> str | None:
+    def parse_dimensions_for_llm(
+        self, metadata: dict, add_indicator_info: bool = True, limit: int = 10
+    ) -> str | None:
         """
         Parse the dimensions from the metadata.
 
@@ -288,7 +313,9 @@ class IndicatorParser(Parser):
         """
         series: dict = self.get_series(metadata)
 
-        dimensions: list[dict[str, str | list[dict[str, str | int]]]] = series.get("dimensions", [])
+        dimensions: list[dict[str, str | list[dict[str, str | int]]]] = series.get(
+            "dimensions", []
+        )
 
         if not dimensions:
             return None
@@ -370,7 +397,9 @@ class DocumentParser(Parser):
 
         date_published: str = document_description.get("date_published", None)
 
-        date_published = date_parse(date_published).strftime("%Y-%m-%d") if date_published else None
+        date_published = (
+            date_parse(date_published).strftime("%Y-%m-%d") if date_published else None
+        )
 
         return date_published
 
@@ -388,7 +417,9 @@ class DocumentParser(Parser):
 
         date_created: str = document_description.get("date_created", None)
 
-        date_created = date_parse(date_created).strftime("%Y-%m-%d") if date_created else None
+        date_created = (
+            date_parse(date_created).strftime("%Y-%m-%d") if date_created else None
+        )
 
         return date_created
 
@@ -534,7 +565,9 @@ class GeospatialParser(Parser):
         extent: dict = identification_info.get("extent", {})
         geographic_coverage: list[dict] = extent.get("geographicElement", [])
         geographies = [
-            {"name": gc.get("geographicDescription")} for gc in geographic_coverage if gc.get("geographicDescription")
+            {"name": gc.get("geographicDescription")}
+            for gc in geographic_coverage
+            if gc.get("geographicDescription")
         ]
 
         geographies = super().parse_geographies(geographies)
@@ -581,7 +614,10 @@ class GeospatialParser(Parser):
 
         doi: str | None = None
 
-        if identifier.get("code") and identifier.get("authority").lower().strip() == "doi":
+        if (
+            identifier.get("code")
+            and identifier.get("authority").lower().strip() == "doi"
+        ):
             doi = identifier.get("code")
 
         return doi
@@ -774,7 +810,9 @@ class ScriptParser(Parser):
 
         authoring_entities: list[dict] = project.get("authoring_entity", [])
         authoring_entities = filter(lambda ae: ae.get("name"), authoring_entities)
-        source: list[str] | None = sorted(set([ae.get("name") for ae in authoring_entities]))
+        source: list[str] | None = sorted(
+            set([ae.get("name") for ae in authoring_entities])
+        )
         source = None if not source else source
 
         return source

--- a/src/ai4data/discovery/metadata/parsers.py
+++ b/src/ai4data/discovery/metadata/parsers.py
@@ -1,0 +1,886 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .utils import get_idno
+
+
+def date_parse(date: str) -> pd.Timestamp:
+    """
+    Parse the date string into a pandas Timestamp.
+    Prefer using pandas to parse dates as it can handle a wider range of date formats, e.g., "2021-01-01", "2021/01/01", periodicities, etc.
+
+    # ILOSTAT_POP_XWAP_SEX_AGE_NB_Q
+    # 1948-Q1
+    # 2024-Q2
+
+    Args:
+        date (str): The date string.
+
+    Returns:
+        pd.Timestamp: The parsed date.
+    """
+    return pd.to_datetime(date)
+
+
+class Parser:
+    metadata_type: str = None
+
+    def parse_idno(self, metadata: dict) -> str:
+        """
+        Parse the idno from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed idno.
+        """
+        assert self.metadata_type, "metadata_type not defined"
+
+        return get_idno(metadata, self.metadata_type)
+
+    def parse_geographies(self, geographies: list[dict], source: str = "name") -> list[str]:
+        """
+        Parse the geographies formated as `[{"name": <geo_name>, "code": <geo_code>}, ...]` into a list of strings.
+
+        Args:
+            geographies (list[dict]): The list of geographies.
+            source (str, optional): The source key to use. Defaults to "name".
+
+        Returns:
+            list[str]: The parsed geographies.
+        """
+        geographic_coverage = filter(lambda gc: gc.get(source), geographies)
+        geographic_coverage = sorted(set([gc.get(source) for gc in geographic_coverage]))
+        geographic_coverage = None if not geographic_coverage else geographic_coverage
+
+        return geographic_coverage
+
+    def parse_periods(self, periods: list[dict], out_format: str = "summary") -> str | dict:
+        """
+        Parse the periods into a single string.
+
+
+        Args:
+            periods (list[dict]): The list of periods.
+            out_format (str, optional): The output format to use, options are "summary" or "details". Defaults to "summary".
+
+        Returns:
+            str: The parsed periods.
+        """
+        assert out_format in ["summary", "details"], f"Invalid out_format: {out_format}"
+
+        coverage = set()
+
+        for period in periods:
+            start = period.get("start")
+            if start:
+                try:
+                    start = date_parse(start).strftime("%Y")
+                    coverage.add(start)
+                except Exception as e:
+                    Warning(f"Could not parse start date: {start} - {e}")
+
+            end = period.get("end")
+            if end:
+                try:
+                    end = date_parse(end).strftime("%Y")
+                    coverage.add(end)
+                except Exception as e:
+                    Warning(f"Could not parse end date: {end} - {e}")
+
+        coverage = sorted(coverage)
+
+        if out_format == "summary":
+            if len(coverage) == 1:
+                return coverage[0]
+            elif len(coverage) == 0:
+                return None
+            else:
+                return " - ".join([coverage[0], coverage[-1]])
+        else:
+            details = dict(
+                year_start=coverage[0] if coverage else None,
+                year_end=coverage[-1] if coverage else None,
+                years=coverage if coverage else None,
+            )
+            return details
+
+    def parse_doi_from_identifiers(self, identifiers: list[dict[str, str]] | dict[str, str]) -> str | None:
+        """
+        Parse the DOI from the metadata identifiers.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed DOI.
+        """
+        doi: str | None = None
+
+        for identifier in identifiers:
+            if identifier.get("type", "").lower().strip() == "doi":
+                doi = identifier.get("identifier")
+                break
+
+        return doi
+
+
+class IndicatorParser(Parser):
+    metadata_type: str = "indicator"
+
+    def get_series(self, metadata: dict) -> dict:
+        """
+        Get the series from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            dict: The series.
+        """
+        return metadata.get("series_description", {})
+
+    def parse_source(self, metadata: dict) -> list[str]:
+        """
+        Parse the source from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            list[str]: The parsed source.
+        """
+        series: dict = self.get_series(metadata)
+
+        source: list[dict] = series.get("authoring_entity", [])
+        source = sorted(s.get("name") for s in filter(lambda s: s.get("name"), source))
+
+        return source
+
+    def parse_geographies(self, metadata: dict) -> list[str]:
+        """
+        Parse the geographies from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            list[str]: The parsed geographies.
+        """
+        series: dict = self.get_series(metadata)
+
+        geographies: list[dict] = series.get("ref_country", [])
+        geographies = super().parse_geographies(geographies)
+
+        return geographies
+
+    def parse_periods(self, metadata: dict, out_format: str = "summary") -> str | dict:
+        """
+        Parse the periods from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+            out_format (str, optional): The output format to use, options are "summary" or "details". Defaults to "summary
+
+        Returns:
+            str | dict: The parsed periods.
+        """
+        series: dict = self.get_series(metadata)
+
+        periods: list[dict] = series.get("time_periods", [])
+        periods = super().parse_periods(periods, out_format=out_format)
+
+        return periods
+
+    def parse_periodicity(self, metadata: dict) -> str:
+        """
+        Parse the periodicity from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed periodicity.
+        """
+        series: dict = self.get_series(metadata)
+
+        periodicity: str = series.get("periodicity", None)
+
+        return periodicity
+
+    def parse_doi(self, metadata: dict) -> str | None:
+        """
+        Parse the DOI from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed DOI.
+        """
+        series: dict = self.get_series(metadata)
+
+        return series.get("doi")
+
+    def parse_dataset(self, metadata: dict) -> str | None:
+        """
+        Parse the dataset from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed dataset.
+        """
+        series: dict = self.get_series(metadata)
+
+        dataset: str | None = series.get("database_id", None)
+
+        return dataset
+
+    def parse_definition(self, metadata: dict) -> str | None:
+        """
+        Parse the definition from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed definition.
+        """
+        series: dict = self.get_series(metadata)
+
+        definition: str | None = series.get("definition_long", series.get("definition_short", None))
+
+        return definition
+
+    def parse_dimensions(self, metadata: dict) -> list[str]:
+        """
+        Parse the dimensions from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            list[str]: The parsed dimensions.
+        """
+        series: dict = self.get_series(metadata)
+
+        dimensions: list[dict[str, str | list[dict[str, str | int]]]] = series.get("dimensions", [])
+
+        dimensions = [dim.get("label") for dim in dimensions if dim.get("label")]
+
+        return sorted(dimensions)
+
+    def parse_dimensions_for_llm(self, metadata: dict, add_indicator_info: bool = True, limit: int = 10) -> str | None:
+        """
+        Parse the dimensions from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+            add_indicator_info (bool, optional): Whether to include the indicator information [name and definition]. Defaults to True.
+            limit (int, optional): The threshold for considering which dimensions to include. Dimensions with code list entries greater than 10 will not be included. Defaults to 10.
+
+        Returns:
+            str: The formatted parsed dimensions. If no dimensions are found, return None.
+        """
+        series: dict = self.get_series(metadata)
+
+        dimensions: list[dict[str, str | list[dict[str, str | int]]]] = series.get("dimensions", [])
+
+        if not dimensions:
+            return None
+
+        output = []
+
+        if add_indicator_info:
+            if series.get("name"):
+                output.append(f"Indicator name: {series.get('name')}")
+
+            definition = self.parse_definition(metadata)
+            if definition:
+                output.append(f"Definition: {definition}")
+
+        for dim in dimensions:
+            if dim.get("code_list") and len(dim.get("code_list")) > limit:
+                continue
+
+            dim_data = []
+            if dim.get("label"):
+                dim_data.append(f"Label: {dim.get('label')}")
+
+            if dim.get("description"):
+                dim_data.append(f"Description: {dim.get('description')}")
+
+            code_list = dim.get("code_list", [])
+            if code_list:
+                dim_data.append("Breakdown:")
+            for cl in code_list:
+                dim_data.append(f"\t- {cl.get('label')}")
+
+            output.append("\n".join(dim_data))
+
+        return "\n\n".join(output)
+
+
+class DocumentParser(Parser):
+    metadata_type: str = "document"
+
+    def get_document_description(self, metadata: dict) -> dict:
+        """
+        Get the document description from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            dict: The document description.
+        """
+        return metadata.get("document_description", {})
+
+    def parse_document_type(self, metadata: dict) -> str:
+        """
+        Parse the document type from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed document type.
+        """
+        document_description = self.get_document_description(metadata)
+
+        document_type: str = document_description.get("type", None)
+
+        return document_type
+
+    def parse_date_published(self, metadata: dict) -> str:
+        """
+        Parse the date published from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed date published.
+        """
+        document_description = self.get_document_description(metadata)
+
+        date_published: str = document_description.get("date_published", None)
+
+        date_published = date_parse(date_published).strftime("%Y-%m-%d") if date_published else None
+
+        return date_published
+
+    def parse_date_created(self, metadata: dict) -> str:
+        """
+        Parse the date created from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed date created.
+        """
+        document_description = self.get_document_description(metadata)
+
+        date_created: str = document_description.get("date_created", None)
+
+        date_created = date_parse(date_created).strftime("%Y-%m-%d") if date_created else None
+
+        return date_created
+
+    def parse_periods(self, metadata: dict, out_format: str = "summary") -> str | dict:
+        """
+        Extract the date_created from the metadata representing the time coverage given by the date_created field.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            str: The time coverage.
+        """
+        date_created = self.parse_date_created(metadata)
+
+        periods = [dict(start=date_created, end=date_created)] if date_created else []
+
+        return super().parse_periods(periods, out_format)
+
+    def parse_geographies(self, metadata: dict) -> list[str]:
+        """
+        Extract the geographic coverage from the metadata.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            list[str]: The geographic coverage.
+        """
+        document = self.get_document_description(metadata)
+
+        geographies: list[dict] = document.get("ref_country", [])
+        geographies = super().parse_geographies(geographies)
+
+        return geographies
+
+    def parse_authors(self, metadata: dict) -> list[str]:
+        """
+        Extract the unique authors from the list of "authors".
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            list[str]: The unique authors.
+        """
+        document = self.get_document_description(metadata)
+        authors: list[dict] = document.get("authors", [])
+        author_names = []
+
+        for author in authors:
+            name: str = ""
+
+            # Check first if the full_name is available
+            if author.get("full_name"):
+                name = author.get("full_name", "")
+            else:
+                if author.get("last_name"):
+                    name += author.get("last_name")
+
+                if author.get("first_name"):
+                    name += "," + author.get("first_name")
+                    name = name.lstrip(",")
+
+            name = name.strip()
+
+            if name and name not in author_names:
+                author_names.append(name)
+
+        return author_names
+
+    def parse_abstract(self, metadata: dict) -> str | None:
+        """
+        Extract the abstract from the metadata.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            str: The abstract.
+        """
+        document = self.get_document_description(metadata)
+        abstract: str | None = document.get("abstract")
+
+        return abstract
+
+    def parse_doi(self, metadata: dict) -> str | None:
+        """
+        Extract the DOI from the metadata.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            str: The DOI.
+        """
+        document = self.get_document_description(metadata)
+
+        identifiers: list[dict[str, str]] = document.get("identifiers", [])
+
+        return super().parse_doi_from_identifiers(identifiers)
+
+
+class GeospatialParser(Parser):
+    metadata_type: str = "geospatial"
+
+    def parse_source(self, metadata: dict) -> list[str]:
+        """
+        Extract the unique authoring entities from the list of "citedResponsibleParty".
+
+        Args:
+            citation (dict): The citation information.
+
+        Returns:
+            list[str]: The unique authoring entities.
+        """
+        description: dict = metadata.get("description", {})
+        identification_info: dict = description.get("identificationInfo", {})
+        citation: dict = identification_info.get("citation", {})
+
+        # TODO: Check if this is the correct way to extract the authoring entities
+        responsible_party: list[dict] = citation.get("citedResponsibleParty", [])
+        source = [crp.get("organisationName") for crp in responsible_party]
+        source = list(filter(None, source))
+        source = None if not source else source
+
+        return source
+
+    def parse_geographies(self, metadata: dict) -> list[str]:
+        """
+        Extract the geographic coverage from the metadata.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            list[str]: The geographic coverage.
+        """
+        # TODO: Check if this is the correct way to extract the geographic coverage
+
+        description: dict = metadata.get("description", {})
+        identification_info: dict = description.get("identificationInfo", {})
+        extent: dict = identification_info.get("extent", {})
+        geographic_coverage: list[dict] = extent.get("geographicElement", [])
+        geographies = [
+            {"name": gc.get("geographicDescription")} for gc in geographic_coverage if gc.get("geographicDescription")
+        ]
+
+        geographies = super().parse_geographies(geographies)
+
+        return geographies
+
+    def parse_periods(self, metadata: dict, out_format: str = "summary") -> str | dict:
+        """
+        Process the time coverage from the citation.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            str: The time coverage.
+        """
+        # TODO: Check if this is the correct way to extract the time coverage
+
+        description: dict = metadata.get("description", {})
+        identification_info: dict = description.get("identificationInfo", {})
+        citation: dict = identification_info.get("citation", {})
+        date: list[dict] = citation.get("date", [])
+        date = [d.get("date") for d in date if d.get("type") == "temporal coverage"]
+        date = sorted(filter(None, date))
+
+        periods = [{"start": d} for d in date]
+
+        return super().parse_periods(periods, out_format)
+
+    def parse_doi(self, metadata: dict) -> str | None:
+        """
+        Extract the DOI from the metadata.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            str: The DOI.
+        """
+        description: dict = metadata.get("description", {})
+        identification_info: dict = description.get("identificationInfo", {})
+        citation: dict = identification_info.get("citation", {})
+        identifier: dict[str, str] = citation.get("identifier", {})
+
+        doi: str | None = None
+
+        if identifier.get("code") and identifier.get("authority").lower().strip() == "doi":
+            doi = identifier.get("code")
+
+        return doi
+
+    def parse_abstract(self, metadata: dict) -> str | None:
+        """
+        Extract the abstract from the metadata.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            str: The abstract.
+        """
+        description: dict = metadata.get("description", {})
+        identification_info: dict = description.get("identificationInfo", {})
+
+        abstract: str | None = identification_info.get("abstract")
+
+        return abstract
+
+
+class MicrodataParser(Parser):
+    metadata_type: str = "microdata"
+
+    def get_study(self, metadata: dict) -> dict:
+        """
+        Get the microdata study description from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            dict: The microdata study description.
+        """
+        study: dict = metadata.get("study_description", {})
+        if not study:
+            study: dict = metadata.get("study_desc", {})
+
+        return study
+
+    def parse_sub_title(self, metadata: dict) -> str | None:
+        """
+        Parse the sub title from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed sub title.
+        """
+        study = self.get_study(metadata)
+        title_statement: dict = study.get("title_statement", {})
+
+        return title_statement.get("sub_title")
+
+    def parse_periods(self, metadata: dict, out_format: str = "summary") -> str | dict:
+        """
+        Parse the period from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed period.
+        """
+        study = self.get_study(metadata)
+
+        # TODO: Does it make sense to take the `time_periods` first, and if not available, take the `coll_dates` as a fallback?
+        # TODO: How do we handle if there are multiple periods?
+
+        study_info: dict = study.get("study_info", {})
+
+        # Check time_periods first
+
+        periods: list[dict] = study_info.get("time_periods", None)
+        if not periods:
+            periods = study_info.get("coll_dates", [])
+
+        return super().parse_periods(periods, out_format)
+
+    def parse_geographies(self, metadata: dict) -> list[str]:
+        """
+        Extract the geographic coverage from the metadata.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            list[str]: The geographic coverage.
+        """
+        study = self.get_study(metadata)
+        study_info: dict = study.get("study_info", {})
+
+        geographies: list[dict] = study_info.get("nation", [])
+
+        return super().parse_geographies(geographies)
+
+    def parse_source(self, metadata: dict) -> list[str] | None:
+        """
+        Extract the unique authoring entities from the list of "authoring_entity".
+
+        Args:
+            study (dict): The study information.
+
+        Returns:
+            list[str]: The unique authoring entities.
+        """
+        study = self.get_study(metadata)
+        authoring_entities: list[dict] = study.get("authoring_entity", [])
+        authoring_entities = filter(lambda ae: ae.get("name"), authoring_entities)
+        source = sorted(set([ae.get("name") for ae in authoring_entities]))
+        source = None if not source else source
+
+        return source
+
+    def parse_doi(self, metadata: dict) -> str | None:
+        """
+        Parse the DOI from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed DOI.
+        """
+        study = self.get_study(metadata)
+        title_statement: dict = study.get("title_statement", {})
+        identifiers: list[dict] = title_statement.get("identifiers", [])
+
+        return super().parse_doi_from_identifiers(identifiers)
+
+    def parse_abstract(self, metadata: dict) -> str | None:
+        """
+        Parse the abstract from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed abstract.
+        """
+        study = self.get_study(metadata)
+        study_info: dict = study.get("study_info", {})
+        abstract: str | None = study_info.get("abstract")
+
+        return abstract
+
+    def parse_access_policy(self, metadata: dict) -> str | None:
+        """
+        Parse the access policy from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed access policy.
+        """
+        access_policy: str | None = metadata.get("access_policy", None)
+
+        return access_policy
+
+
+class ScriptParser(Parser):
+    metadata_type: str = "script"
+
+    def get_project(self, metadata: dict) -> dict:
+        """
+        Get the script project description from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            dict: The script project description.
+        """
+        return metadata.get("project_desc", {})
+
+    def parse_source(self, metadata: dict) -> list[str] | None:
+        """
+        Extract the unique authoring entities from the list of "authoring_entity".
+
+        Args:
+            project (dict): The project information.
+
+        Returns:
+            list[str]: The unique authoring entities.
+        """
+        project = self.get_project(metadata)
+
+        authoring_entities: list[dict] = project.get("authoring_entity", [])
+        authoring_entities = filter(lambda ae: ae.get("name"), authoring_entities)
+        source: list[str] | None = sorted(set([ae.get("name") for ae in authoring_entities]))
+        source = None if not source else source
+
+        return source
+
+    def parse_geographies(self, metadata: dict) -> list[str] | None:
+        """
+        Extract the geographic coverage from the metadata.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            list[str]: The geographic coverage.
+        """
+        project = self.get_project(metadata)
+        geographies: list[dict] = project.get("geographic_units", [])
+
+        return super().parse_geographies(geographies)
+
+    def parse_periods(self, metadata: dict, out_format: str = "summary") -> str | dict:
+        """
+        Parse the period from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed period.
+        """
+        project = self.get_project(metadata)
+        production_date = project.get("production_date", [])
+        periods = [{"start": date} for date in production_date]
+
+        return super().parse_periods(periods, out_format)
+
+    def parse_language(self, metadata: dict) -> str | None:
+        """
+        Extract the programming language from the metadata.
+
+        Args:
+            metadata (dict): The metadata information.
+
+        Returns:
+            str: The programming language.
+        """
+        project = self.get_project(metadata)
+
+        software: list[dict] = project.get("software", [])
+        software = filter(lambda s: s.get("name"), software)
+        software = sorted(set([s.get("name") for s in software]))
+
+        software = None if not software else ", ".join(software)
+
+        return software
+
+    def parse_doi(self, metadata: dict) -> str | None:
+        """
+        Parse the DOI from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed DOI.
+        """
+        project = self.get_project(metadata)
+        title_statement: dict = project.get("title_statement", {})
+
+        identifiers: list[dict] = title_statement.get("identifiers", [])
+
+        return super().parse_doi_from_identifiers(identifiers)
+
+    def parse_abstract(self, metadata: dict) -> str | None:
+        """
+        Parse the abstract from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed abstract.
+        """
+        project = self.get_project(metadata)
+
+        abstract: str | None = project.get("abstract")
+
+        return abstract
+
+    def parse_github(self, metadata: dict) -> str | None:
+        """
+        Parse the github from the metadata.
+
+        Args:
+            metadata (dict): The metadata.
+
+        Returns:
+            str: The parsed github.
+        """
+        project = self.get_project(metadata)
+        repository: list[dict[str, str]] = project.get("repository_uri", {})
+
+        github: str | None = None
+
+        for repo in repository:
+            if repo.get("type", "").lower().strip() == "github":
+                github = repo.get("uri")
+                break
+
+        return github

--- a/src/ai4data/discovery/metadata/templates/document/document__abstract__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/document/document__abstract__page_content.jinja2
@@ -1,0 +1,1 @@
+{% if document_description.abstract %}{{ document_description.abstract }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/document/document__title__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/document/document__title__page_content.jinja2
@@ -1,0 +1,1 @@
+{% if document_description.title_statement.title %}{{ document_description.title_statement.title }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/document_page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/document_page_content.jinja2
@@ -1,0 +1,3 @@
+{% if document_description.title_statement.title %}Title: {{ document_description.title_statement.title }}{% endif %}
+{% if document_description.abstract %}
+Abstract: {{ document_description.abstract }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/geospatial/geospatial__abstract__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/geospatial/geospatial__abstract__page_content.jinja2
@@ -1,0 +1,1 @@
+{% if description.identificationInfo.citation.title %}{{ description.identificationInfo.citation.title }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/geospatial/geospatial__abstract__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/geospatial/geospatial__abstract__page_content.jinja2
@@ -1,1 +1,1 @@
-{% if description.identificationInfo.citation.title %}{{ description.identificationInfo.citation.title }}{% endif %}
+{% if description.identificationInfo.abstract %}{{ description.identificationInfo.abstract }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/geospatial/geospatial__title__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/geospatial/geospatial__title__page_content.jinja2
@@ -1,1 +1,1 @@
-{% if description.identificationInfo.abstract %}{{ description.identificationInfo.abstract }}{% endif %}
+{% if description.identificationInfo.citation.title %}{{ description.identificationInfo.citation.title }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/geospatial/geospatial__title__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/geospatial/geospatial__title__page_content.jinja2
@@ -1,0 +1,1 @@
+{% if description.identificationInfo.abstract %}{{ description.identificationInfo.abstract }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/indicator/indicator__definition__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/indicator/indicator__definition__page_content.jinja2
@@ -1,0 +1,2 @@
+{% if series_description.definition_long or series_description.definition_short %}{{ series_description.definition_long
+or series_description.definition_short }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/indicator/indicator__name__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/indicator/indicator__name__page_content.jinja2
@@ -1,0 +1,1 @@
+{% if series_description.name %}{{ series_description.name }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/indicator_page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/indicator_page_content.jinja2
@@ -1,0 +1,3 @@
+{% if series_description.name %}Indicator name: {{ series_description.name }}{% endif %}
+{% if series_description.definition_long or series_description.definition_short %}
+Definition: {{ series_description.definition_long or series_description.definition_short }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/microdata/microdata__abstract__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/microdata/microdata__abstract__page_content.jinja2
@@ -1,0 +1,1 @@
+{% if study_desc.study_info.abstract %}{{ study_desc.study_info.abstract }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/microdata/microdata__sub_title__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/microdata/microdata__sub_title__page_content.jinja2
@@ -1,0 +1,1 @@
+{% if study_desc.title_statement.sub_title %}{{ study_desc.title_statement.sub_title }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/microdata/microdata__title__page_content.jinja2
+++ b/src/ai4data/discovery/metadata/templates/microdata/microdata__title__page_content.jinja2
@@ -1,0 +1,1 @@
+{% if study_desc.title_statement.title %}{{ study_desc.title_statement.title }}{% endif %}

--- a/src/ai4data/discovery/metadata/templates/render.py
+++ b/src/ai4data/discovery/metadata/templates/render.py
@@ -1,0 +1,56 @@
+import os
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from ...config import EMBEDDING_CONTENT_TEMPLATES_PATH
+
+
+def get_searchpath(metadata_type: str, searchpath: str = None):
+    """
+    Get the searchpath for a metadata type.
+
+    Args:
+        metadata_type (str): The type of metadata.
+        searchpath (str): The path to search for the Jinja2 template.
+
+    Returns:
+        str: The searchpath.
+    """
+    searchpath = searchpath or EMBEDDING_CONTENT_TEMPLATES_PATH
+    searchpath = os.path.join(searchpath, metadata_type)
+
+    return searchpath
+
+
+def render_embedding_content(metadata: dict, metadata_type: str, field: str, searchpath: str = None):
+    """
+    Render the content for a metadata type using a Jinja2 template.
+    The content is used to generate vector embeddings for the metadata.
+    The template is loaded from the ``searchpath``, which defaults to
+    ``EMBEDDING_CONTENT_TEMPLATES_PATH`` from ``ai4data.discovery.config``
+    (override with env ``AI4DATA_EMBEDDING_CONTENT_TEMPLATES_PATH``) if not provided explicitly.
+
+    Args:
+        metadata (dict): The metadata to render.
+        metadata_type (str): The type of metadata.
+        field (str): The field to render.
+        searchpath (str): The path to search for the Jinja2 template.
+
+    Returns:
+        str: The rendered content.
+    """
+
+    # Load the Jinja2 environment
+    searchpath = get_searchpath(metadata_type, searchpath)
+
+    env = Environment(loader=FileSystemLoader(searchpath=searchpath), autoescape=select_autoescape())
+
+    template_name = f"{metadata_type}__{field}__page_content.jinja2"
+
+    # Load the template
+    template = env.get_template(template_name)
+
+    # Render the template with metadata
+    page_content = template.render(metadata)
+
+    return page_content

--- a/src/ai4data/discovery/metadata/utils.py
+++ b/src/ai4data/discovery/metadata/utils.py
@@ -1,0 +1,112 @@
+# Description: Utility functions for metadata
+import hashlib
+import json
+import re
+import uuid
+
+from ..config import metadata_catalog
+from ..paths import get_metadata_ids_path
+
+IDNO_KEYS = dict(
+    indicator="series_description.idno",
+    document="document_description.title_statement.idno",
+    microdata="study_desc.title_statement.idno",
+    geospatial="description.idno",
+)
+
+
+def create_uuid_from_string(val: str):
+    hex_string = hashlib.md5(val.encode("UTF-8")).hexdigest()
+
+    return uuid.UUID(hex=hex_string)
+
+
+def get_idno_key(metadata_type: str, prefix: str = None) -> str:
+    """
+    Get the key for the idno for the given metadata type. This is useful as input to the group_search if the metadata is not normalized.
+
+    Args:
+        metadata_type (str): The metadata type.
+        prefix (str, optional): The prefix to add to the key. Defaults to None.
+
+    Returns:
+        str: The key for the idno.
+    """
+    assert metadata_type in IDNO_KEYS, f"Metadata type {metadata_type} not supported"
+
+    key = IDNO_KEYS.get(metadata_type)
+
+    if prefix:
+        key = f"{prefix}.{key}"
+
+    return key
+
+
+def get_idno(metadata: dict, metadata_type: str) -> str:
+    if metadata_type == "indicator":
+        idno = metadata["series_description"]["idno"]
+    elif metadata_type == "document":
+        idno = metadata["document_description"]["title_statement"]["idno"]
+    elif metadata_type == "microdata":
+        idno = metadata["study_desc"]["title_statement"]["idno"]
+    elif metadata_type == "geospatial":
+        idno = metadata["description"]["idno"]
+    else:
+        raise ValueError(f"Type {metadata_type} not supported")
+
+    return idno
+
+
+def get_metadata_ids(metadata_type: str) -> list[dict]:
+    """
+    Get the metadata ids collected from the metadata catalog for the given type.
+    """
+
+    fpath = get_metadata_ids_path(metadata_type=metadata_type)
+
+    with open(fpath) as f:
+        metadata_ids = json.load(f)
+
+    return metadata_ids
+
+
+def parse_dimension_label_values(metadata: dict) -> dict[str, list]:
+    pattern = re.compile(r"\[(.*?)\]")
+
+    series: dict = metadata.get("series_description", {})
+    dimensions: list[dict] = series.get("dimensions", [])
+    dimension_label_values: dict[str, list] = {}
+
+    for dimension in dimensions:
+        dimension_label = dimension["label"]
+        m = pattern.match(dimension_label)
+        if m:
+            label = m.group(1)
+            value = pattern.sub("", dimension_label, count=1).strip()
+            if label in dimension_label_values:
+                dimension_label_values[label].append(value)
+            else:
+                dimension_label_values[label] = [value]
+
+    if len(dimensions) > 0:
+        assert len(dimension_label_values) > 0, "No dimension label values found despite having dimensions"
+
+    return dimension_label_values
+
+
+IDNO_ID_MAP = {}
+
+_document_ids_path = get_metadata_ids_path(metadata_type="document")
+if _document_ids_path.is_file():
+    metadata_ids = get_metadata_ids(metadata_type="document")
+    for metadata_id in metadata_ids:
+        IDNO_ID_MAP[metadata_id["idno"]] = metadata_id["id"]
+
+
+def get_thumbnail_url(idno: str) -> str:
+    if idno not in IDNO_ID_MAP:
+        return None
+
+    db_id = IDNO_ID_MAP[idno]
+
+    return metadata_catalog.thumbnail_url.format(db_id=db_id)

--- a/src/ai4data/discovery/metadata/utils.py
+++ b/src/ai4data/discovery/metadata/utils.py
@@ -89,7 +89,9 @@ def parse_dimension_label_values(metadata: dict) -> dict[str, list]:
                 dimension_label_values[label] = [value]
 
     if len(dimensions) > 0:
-        assert len(dimension_label_values) > 0, "No dimension label values found despite having dimensions"
+        assert len(dimension_label_values) > 0, (
+            "No dimension label values found despite having dimensions"
+        )
 
     return dimension_label_values
 
@@ -103,7 +105,7 @@ if _document_ids_path.is_file():
         IDNO_ID_MAP[metadata_id["idno"]] = metadata_id["id"]
 
 
-def get_thumbnail_url(idno: str) -> str:
+def get_thumbnail_url(idno: str) -> str | None:
     if idno not in IDNO_ID_MAP:
         return None
 

--- a/src/ai4data/discovery/paths.py
+++ b/src/ai4data/discovery/paths.py
@@ -1,0 +1,88 @@
+"""
+On-disk layout for discovery workflows (catalog cache, scraped id lists, PDF cache, contextual dimensions).
+
+The data root is set via :func:`init_discovery_paths` and/or env ``AI4DATA_DISCOVERY_DATA_PATH``; see ``README.md``.
+
+**Precedence:** explicit path passed to :func:`init_discovery_paths` wins; otherwise ``AI4DATA_DISCOVERY_DATA_PATH``
+if set; otherwise ``<package>/ai4data/data`` relative to this file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config import discovery_data
+from .type_normalization import normalize_catalog_metadata_type
+
+# Populated by init_discovery_paths (and module load default).
+_data_root: Path | None = None
+METADATA_IDS_DIR: Path
+METADATA_CACHE_DIR: Path
+DOCUMENT_CACHE_DIR: Path
+
+
+def _default_data_root() -> Path:
+    """Package-relative ``ai4data/data``, or ``discovery_data.data_path`` when set."""
+    if discovery_data.data_path is not None:
+        return discovery_data.data_path.expanduser().resolve()
+    return Path(__file__).resolve().parent.parent / "data"
+
+
+def init_discovery_paths(data_path: Path | None = None) -> None:
+    """
+    Set the root directory for discovery cache and id-list paths.
+
+    Pass ``data_path`` to force a root regardless of ``AI4DATA_DISCOVERY_DATA_PATH``.
+    Pass ``None`` to use the env-based default from :func:`_default_data_root`.
+    Safe to call multiple times (e.g. in tests).
+    """
+    global _data_root, METADATA_IDS_DIR, METADATA_CACHE_DIR, DOCUMENT_CACHE_DIR
+    root = data_path if data_path is not None else _default_data_root()
+    _data_root = root
+    METADATA_IDS_DIR = root / "metadata_ids"
+    METADATA_CACHE_DIR = root / "metadata_cache"
+    DOCUMENT_CACHE_DIR = root / "document_cache"
+
+
+def get_discovery_data_root() -> Path:
+    """Return the current discovery data root (after :func:`init_discovery_paths`)."""
+    if _data_root is None:
+        init_discovery_paths()
+    assert _data_root is not None
+    return _data_root
+
+
+init_discovery_paths()
+
+
+def ensure_dir_exists(path: Path) -> Path:
+    if not path.exists():
+        path.mkdir(parents=True, exist_ok=True)
+
+    return path
+
+
+def construct_path(directory: Path, filename: str) -> Path:
+    ensure_dir_exists(directory)
+    return directory / filename
+
+
+def get_metadata_ids_path(metadata_type: str) -> Path:
+    metadata_type = normalize_catalog_metadata_type(metadata_type)
+
+    return construct_path(METADATA_IDS_DIR, f"metadata_ids_{metadata_type}.json")
+
+
+def get_metadata_cache_path(idno: str, metadata_type: str) -> Path:
+    return construct_path(METADATA_CACHE_DIR / metadata_type, f"{metadata_type}_{idno}.json")
+
+
+def get_document_cache_path(idno: str, metadata_type: str) -> Path:
+    return construct_path(DOCUMENT_CACHE_DIR / metadata_type, f"{metadata_type}_{idno}.pdf")
+
+
+def get_contextualized_dimensions_path(idno: str, raw: bool = False) -> Path:
+    root = get_discovery_data_root()
+    if raw:
+        return root / "contextual_dimensions" / idno / f"contextual_dimensions.{idno}.raw.json"
+    return root / "contextual_dimensions" / idno / f"contextual_dimensions.{idno}.txt"

--- a/src/ai4data/discovery/paths.py
+++ b/src/ai4data/discovery/paths.py
@@ -73,16 +73,32 @@ def get_metadata_ids_path(metadata_type: str) -> Path:
     return construct_path(METADATA_IDS_DIR, f"metadata_ids_{metadata_type}.json")
 
 
-def get_metadata_cache_path(idno: str, metadata_type: str) -> Path:
-    return construct_path(METADATA_CACHE_DIR / metadata_type, f"{metadata_type}_{idno}.json")
+def get_metadata_cache_path(
+    idno: str, metadata_type: str, include_resources: bool = False
+) -> Path:
+    if include_resources:
+        return construct_path(
+            METADATA_CACHE_DIR / metadata_type, f"{metadata_type}_{idno}.res.json"
+        )
+    else:
+        return construct_path(
+            METADATA_CACHE_DIR / metadata_type, f"{metadata_type}_{idno}.json"
+        )
 
 
 def get_document_cache_path(idno: str, metadata_type: str) -> Path:
-    return construct_path(DOCUMENT_CACHE_DIR / metadata_type, f"{metadata_type}_{idno}.pdf")
+    return construct_path(
+        DOCUMENT_CACHE_DIR / metadata_type, f"{metadata_type}_{idno}.pdf"
+    )
 
 
 def get_contextualized_dimensions_path(idno: str, raw: bool = False) -> Path:
     root = get_discovery_data_root()
     if raw:
-        return root / "contextual_dimensions" / idno / f"contextual_dimensions.{idno}.raw.json"
+        return (
+            root
+            / "contextual_dimensions"
+            / idno
+            / f"contextual_dimensions.{idno}.raw.json"
+        )
     return root / "contextual_dimensions" / idno / f"contextual_dimensions.{idno}.txt"

--- a/src/ai4data/discovery/processors/__init__.py
+++ b/src/ai4data/discovery/processors/__init__.py
@@ -1,0 +1,1 @@
+"""Document and PDF helpers used by discovery metadata (e.g. chunking PDFs for indexing)."""

--- a/src/ai4data/discovery/processors/document.py
+++ b/src/ai4data/discovery/processors/document.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from io import BytesIO, StringIO
+from typing import Any
+
+import numpy as np
+from bs4 import BeautifulSoup
+from langchain_community.document_loaders.pdf import BasePDFLoader, PyMuPDFLoader
+from langchain_core.documents import Document as LangchainDocument
+from langchain_huggingface.embeddings import HuggingFaceEmbeddings
+from sklearn.metrics.pairwise import cosine_similarity
+from tika import parser
+
+_embedding_factory: Callable[[], Any] | None = None
+_text_splitter_factory: Callable[[], Any] | None = None
+_cluster_fn: Callable[[np.ndarray], Any] | None = None
+
+
+def configure_discovery_processors(
+    *,
+    embedding_factory: Callable[[], Any] | None = None,
+    text_splitter_factory: Callable[[], Any] | None = None,
+    cluster_fn: Callable[[np.ndarray], Any] | None = None,
+) -> None:
+    """
+    Wire embedding model, text splitter, and clustering used by :func:`embed_documents` / :func:`get_doc_reps`.
+
+    The monolith registers defaults via :mod:`ai4data.discovery_wiring`; call this in tests with fakes.
+    """
+    global _embedding_factory, _text_splitter_factory, _cluster_fn
+    if embedding_factory is not None:
+        _embedding_factory = embedding_factory
+    if text_splitter_factory is not None:
+        _text_splitter_factory = text_splitter_factory
+    if cluster_fn is not None:
+        _cluster_fn = cluster_fn
+
+
+def _get_embedding_model():
+    if _embedding_factory is None:
+        raise RuntimeError(
+            "Discovery processors are not wired: import ai4data.discovery_wiring (or call "
+            "configure_discovery_processors(embedding_factory=...)) before using embed_documents / get_doc_reps."
+        )
+    return _embedding_factory()
+
+
+def _get_text_splitter():
+    if _text_splitter_factory is None:
+        raise RuntimeError(
+            "Discovery processors are not wired: import ai4data.discovery_wiring (or call "
+            "configure_discovery_processors(text_splitter_factory=...)) before using get_doc_reps."
+        )
+    return _text_splitter_factory()
+
+
+def _get_cluster_fn():
+    if _cluster_fn is None:
+        raise RuntimeError(
+            "Discovery processors are not wired: import ai4data.discovery_wiring (or call "
+            "configure_discovery_processors(cluster_fn=...)) before using get_doc_reps."
+        )
+    return _cluster_fn
+
+
+# @task(log_prints=True)
+def load_pdf(
+    file_path: str, pdf_loader_cls: BasePDFLoader = PyMuPDFLoader, loader_kwargs: dict = None, load_kwargs: dict = None
+) -> list[LangchainDocument]:
+    """
+    Load a PDF file and return a LangchainDocument object.
+
+    Args:
+        file_path: The path to the PDF file.
+        pdf_loader_cls: The PDF loader class to use.
+        loader_kwargs: The loader kwargs.
+        load_kwargs: The load kwargs.
+
+    Returns:
+        A list of LangchainDocument objects.
+
+    Raises:
+        Exception: If an error occurs during loading.
+    """
+    try:
+        loader_kwargs = loader_kwargs or {}
+        load_kwargs = load_kwargs or {}
+
+        loader = pdf_loader_cls(file_path, **loader_kwargs)
+        docs = loader.load(**load_kwargs)
+
+    except Exception as exception:
+        print(f"load_pdf Exception {exception}: {file_path}")
+        raise exception
+
+    return docs
+
+
+def load_doc(
+    file_path: str = None,
+    stream: BytesIO = None,
+    pdf_loader_cls: BasePDFLoader = PyMuPDFLoader,
+    loader_kwargs: dict = None,
+    load_kwargs: dict = None,
+) -> list[LangchainDocument]:
+    """
+    # pdf = pymupdf.open(stream=io.BytesIO(file.file.read()), filetype="pdf")
+    stream = io.BytesIO(file.file.read())
+    """
+    if file_path:
+        return load_pdf(file_path, pdf_loader_cls, loader_kwargs, load_kwargs)
+    elif stream:
+        import pymupdf
+
+        # TODO: Improve synchronization of the loader and the splitter options with the load_pdf function.
+        # TODO: Handle the case when the stream is not a PDF file.
+        pdf = pymupdf.open(stream=stream, filetype="pdf")
+
+        text_splits = [page.get_text() for page in pdf]
+        # text_splits = TextSplitterSingleton.get_instance().split_text("\n\n".join(text_splits))
+
+        return [LangchainDocument(page_content=split) for split in text_splits]
+    else:
+        raise ValueError("Either file_path or stream must be provided.")
+
+
+def merge_split_docs(docs: list[LangchainDocument], splitter) -> list[LangchainDocument]:
+    """
+    Merge the documents into one document, then split them into chunks defined in the splitter instance.
+
+    NOTE: This removes the metadata from the documents and only keeps the metadata from the first document.
+    TODO: Find a way to keep the PDF metadata. See: https://github.com/avsolatorio/data-use/blob/887e46ce24e27edac0658786dae0645571b889db/src/data_use/text_splitter.py
+
+    Args:
+        docs: The list of LangChain documents to merge and split.
+
+    Returns:
+        A list of LangchainDocument objects.
+    """
+
+    page_content = "\n\n".join([doc.page_content for doc in docs])
+
+    chunks = splitter.split_text(page_content)
+    metadata = docs[0].metadata
+
+    return [LangchainDocument(page_content=chunk, metadata=metadata) for chunk in chunks]
+
+
+def embed_documents(
+    docs: list[str | LangchainDocument], embedding_model: HuggingFaceEmbeddings | None = None
+) -> np.ndarray:
+    """
+    Embed the documents and return a list of embedded documents.
+
+    Args:
+        embedding_model: The embedding model from LangChain (HuggingFaceEmbeddings).
+        docs: The list of documents to embed.
+    """
+    if embedding_model is None:
+        embedding_model = _get_embedding_model()
+
+    if isinstance(docs[0], LangchainDocument):
+        docs = [doc.page_content for doc in docs]
+
+    return np.array(embedding_model.embed_documents(docs))
+
+
+# @task
+def get_doc_reps(
+    docs: list[LangchainDocument], embedding_model: HuggingFaceEmbeddings | None = None, text_splitter=None
+) -> list[LangchainDocument]:
+    """
+    Get the document representations by merging and splitting the documents, then embedding them.
+
+    Args:
+        docs: The list of LangChain documents to merge and split.
+        splitter: The text splitter to use.
+
+    Returns:
+        The document representations.
+    """
+    if embedding_model is None:
+        embedding_model = _get_embedding_model()
+
+    if text_splitter is None:
+        text_splitter = _get_text_splitter()
+
+    # Merge and split the documents
+    split_docs = merge_split_docs(docs, text_splitter)
+
+    # Embed the documents
+    doc_reps = embed_documents(split_docs, embedding_model)
+
+    # Cluster the document representations and get the cluster info
+    cluster_info = _get_cluster_fn()(doc_reps)
+
+    labels = sorted(set(cluster_info.labels))
+
+    # Find the representative document for each cluster
+    doc_rep_docs = []
+
+    for label in labels:
+        orig_idx = np.where(cluster_info.labels == label)[0]
+        sub_vecs = doc_reps[cluster_info.labels == label]
+
+        # Get the cosine similarity between the cluster center and the sub vectors
+        sims = cosine_similarity(cluster_info.cluster_centers[label].reshape(1, -1), sub_vecs)
+
+        # Get the original index
+        idx = orig_idx[np.argmax(sims)]
+
+        # Append the representative document
+        doc_rep_docs.append(split_docs[idx])
+
+    return doc_rep_docs
+
+
+def tika_parse_pdf(file_path: str) -> list[dict]:
+    """
+    Parse the PDF file and return the parsed content per page using Apache Tika.
+
+    # https://github.com/chrismattmann/tika-python/issues/191#issuecomment-552593722
+    """
+    _buffer = StringIO()
+    file_data = []
+
+    data = parser.from_file(file_path, xmlContent=True)
+    xhtml_data = BeautifulSoup(data["content"])
+
+    for page, content in enumerate(xhtml_data.find_all("div", attrs={"class": "page"})):
+        print(f"Parsing page {page+1} of pdf file...")
+        _buffer.write(str(content))
+
+        parsed_content = parser.from_buffer(_buffer.getvalue())
+
+        _buffer.seek(0)
+        _buffer.truncate()
+        file_data.append({"id": "page_" + str(page + 1), "content": parsed_content["content"]})
+
+    return file_data

--- a/src/ai4data/discovery/processors/document.py
+++ b/src/ai4data/discovery/processors/document.py
@@ -66,7 +66,10 @@ def _get_cluster_fn():
 
 # @task(log_prints=True)
 def load_pdf(
-    file_path: str, pdf_loader_cls: BasePDFLoader = PyMuPDFLoader, loader_kwargs: dict = None, load_kwargs: dict = None
+    file_path: str,
+    pdf_loader_cls: BasePDFLoader = PyMuPDFLoader,
+    loader_kwargs: dict = None,
+    load_kwargs: dict = None,
 ) -> list[LangchainDocument]:
     """
     Load a PDF file and return a LangchainDocument object.
@@ -92,7 +95,7 @@ def load_pdf(
 
     except Exception as exception:
         print(f"load_pdf Exception {exception}: {file_path}")
-        raise exception
+        raise
 
     return docs
 
@@ -125,7 +128,9 @@ def load_doc(
         raise ValueError("Either file_path or stream must be provided.")
 
 
-def merge_split_docs(docs: list[LangchainDocument], splitter) -> list[LangchainDocument]:
+def merge_split_docs(
+    docs: list[LangchainDocument], splitter
+) -> list[LangchainDocument]:
     """
     Merge the documents into one document, then split them into chunks defined in the splitter instance.
 
@@ -144,11 +149,14 @@ def merge_split_docs(docs: list[LangchainDocument], splitter) -> list[LangchainD
     chunks = splitter.split_text(page_content)
     metadata = docs[0].metadata
 
-    return [LangchainDocument(page_content=chunk, metadata=metadata) for chunk in chunks]
+    return [
+        LangchainDocument(page_content=chunk, metadata=metadata) for chunk in chunks
+    ]
 
 
 def embed_documents(
-    docs: list[str | LangchainDocument], embedding_model: HuggingFaceEmbeddings | None = None
+    docs: list[str | LangchainDocument],
+    embedding_model: HuggingFaceEmbeddings | None = None,
 ) -> np.ndarray:
     """
     Embed the documents and return a list of embedded documents.
@@ -160,6 +168,9 @@ def embed_documents(
     if embedding_model is None:
         embedding_model = _get_embedding_model()
 
+    if not docs:
+        raise ValueError("No documents to embed.")
+
     if isinstance(docs[0], LangchainDocument):
         docs = [doc.page_content for doc in docs]
 
@@ -168,7 +179,9 @@ def embed_documents(
 
 # @task
 def get_doc_reps(
-    docs: list[LangchainDocument], embedding_model: HuggingFaceEmbeddings | None = None, text_splitter=None
+    docs: list[LangchainDocument],
+    embedding_model: HuggingFaceEmbeddings | None = None,
+    text_splitter=None,
 ) -> list[LangchainDocument]:
     """
     Get the document representations by merging and splitting the documents, then embedding them.
@@ -205,7 +218,9 @@ def get_doc_reps(
         sub_vecs = doc_reps[cluster_info.labels == label]
 
         # Get the cosine similarity between the cluster center and the sub vectors
-        sims = cosine_similarity(cluster_info.cluster_centers[label].reshape(1, -1), sub_vecs)
+        sims = cosine_similarity(
+            cluster_info.cluster_centers[label].reshape(1, -1), sub_vecs
+        )
 
         # Get the original index
         idx = orig_idx[np.argmax(sims)]
@@ -229,13 +244,15 @@ def tika_parse_pdf(file_path: str) -> list[dict]:
     xhtml_data = BeautifulSoup(data["content"])
 
     for page, content in enumerate(xhtml_data.find_all("div", attrs={"class": "page"})):
-        print(f"Parsing page {page+1} of pdf file...")
+        print(f"Parsing page {page + 1} of pdf file...")
         _buffer.write(str(content))
 
         parsed_content = parser.from_buffer(_buffer.getvalue())
 
         _buffer.seek(0)
         _buffer.truncate()
-        file_data.append({"id": "page_" + str(page + 1), "content": parsed_content["content"]})
+        file_data.append(
+            {"id": "page_" + str(page + 1), "content": parsed_content["content"]}
+        )
 
     return file_data

--- a/src/ai4data/discovery/processors/document.py
+++ b/src/ai4data/discovery/processors/document.py
@@ -26,7 +26,7 @@ def configure_discovery_processors(
     """
     Wire embedding model, text splitter, and clustering used by :func:`embed_documents` / :func:`get_doc_reps`.
 
-    The monolith registers defaults via :mod:`ai4data.discovery_wiring`; call this in tests with fakes.
+    Default registration: :func:`ai4data.discovery.wiring.register_discovery_processors`. Call this in tests with fakes.
     """
     global _embedding_factory, _text_splitter_factory, _cluster_fn
     if embedding_factory is not None:
@@ -40,8 +40,8 @@ def configure_discovery_processors(
 def _get_embedding_model():
     if _embedding_factory is None:
         raise RuntimeError(
-            "Discovery processors are not wired: import ai4data.discovery_wiring (or call "
-            "configure_discovery_processors(embedding_factory=...)) before using embed_documents / get_doc_reps."
+            "Discovery processors are not wired: call ai4data.discovery.wiring.register_discovery_processors() "
+            "(or configure_discovery_processors(embedding_factory=...)) before using embed_documents / get_doc_reps."
         )
     return _embedding_factory()
 
@@ -49,8 +49,8 @@ def _get_embedding_model():
 def _get_text_splitter():
     if _text_splitter_factory is None:
         raise RuntimeError(
-            "Discovery processors are not wired: import ai4data.discovery_wiring (or call "
-            "configure_discovery_processors(text_splitter_factory=...)) before using get_doc_reps."
+            "Discovery processors are not wired: call ai4data.discovery.wiring.register_discovery_processors() "
+            "(or configure_discovery_processors(text_splitter_factory=...)) before using get_doc_reps."
         )
     return _text_splitter_factory()
 
@@ -58,8 +58,8 @@ def _get_text_splitter():
 def _get_cluster_fn():
     if _cluster_fn is None:
         raise RuntimeError(
-            "Discovery processors are not wired: import ai4data.discovery_wiring (or call "
-            "configure_discovery_processors(cluster_fn=...)) before using get_doc_reps."
+            "Discovery processors are not wired: call ai4data.discovery.wiring.register_discovery_processors() "
+            "(or configure_discovery_processors(cluster_fn=...)) before using get_doc_reps."
         )
     return _cluster_fn
 

--- a/src/ai4data/discovery/semantic_cluster_embedding.py
+++ b/src/ai4data/discovery/semantic_cluster_embedding.py
@@ -1,0 +1,42 @@
+from typing import NamedTuple
+
+import numpy as np
+from sklearn.cluster import KMeans
+
+
+class ClusteringResult(NamedTuple):
+    cluster_centers: np.ndarray
+    labels: np.ndarray
+
+
+def semantic_cluster_embedding(data: np.ndarray, n_clusters: int = 10, **kmeans_kwargs) -> ClusteringResult:
+    """
+    Perform KMeans clustering on the embedding data to obtain semantic clusters.
+
+    Args:
+        data (np.ndarray): The embedding data, expected to be of shape (n_samples, n_features).
+        n_clusters (int): The number of clusters to create. Defaults to 10.
+        **kmeans_kwargs: Additional keyword arguments to pass to the KMeans constructor.
+
+    Returns:
+        ClusteringResult: A named tuple containing the cluster centers and labels.
+
+    Raises:
+        ValueError: If `n_clusters` is greater than the number of data points.
+    """
+
+    # Ensure that the number of clusters does not exceed the number of data points
+    if n_clusters > len(data):
+        Warning(
+            f"n_clusters ({n_clusters}) cannot be greater than the number of data points ({len(data)}). Setting n_clusters to {len(data)}."
+        )
+
+        n_clusters = len(data)
+
+    n_clusters = min(n_clusters, len(data))
+
+    kmeans = KMeans(n_clusters=n_clusters, **kmeans_kwargs)
+    kmeans.fit(data)
+
+    # Return the cluster centers and labels as a named tuple
+    return ClusteringResult(cluster_centers=kmeans.cluster_centers_, labels=kmeans.labels_)

--- a/src/ai4data/discovery/type_normalization.py
+++ b/src/ai4data/discovery/type_normalization.py
@@ -1,0 +1,12 @@
+"""Catalog metadata type strings used in filenames (aligned with NADA API aliases)."""
+
+
+def normalize_catalog_metadata_type(type: str) -> str:
+    """Map API-facing types to normalized storage names (e.g. timeseries -> indicator)."""
+    if type == "timeseries":
+        type = "indicator"
+
+    if type == "survey":
+        type = "microdata"
+
+    return type

--- a/src/ai4data/discovery/wiring.py
+++ b/src/ai4data/discovery/wiring.py
@@ -1,0 +1,23 @@
+"""Wire default embedding model, token splitter, and clustering into discovery processors."""
+
+from __future__ import annotations
+
+_registered = False
+
+
+def register_discovery_processors() -> None:
+    """Idempotent: register defaults for :func:`~ai4data.discovery.processors.document.embed_documents` / ``get_doc_reps``."""
+    global _registered
+    if _registered:
+        return
+
+    from .embeddings import default_embedding_factory, default_text_splitter_factory
+    from .processors.document import configure_discovery_processors
+    from .semantic_cluster_embedding import semantic_cluster_embedding
+
+    configure_discovery_processors(
+        embedding_factory=default_embedding_factory,
+        text_splitter_factory=default_text_splitter_factory,
+        cluster_fn=semantic_cluster_embedding,
+    )
+    _registered = True

--- a/tests/test_discovery_auth.py
+++ b/tests/test_discovery_auth.py
@@ -1,13 +1,15 @@
-"""Tests for :mod:`ai4data.discovery.auth` and the auth-header wiring across catalog/HTTP
-and document download paths.
+"""Tests for :mod:`ai4data.discovery.auth` and the auth wiring across catalog/HTTP and
+document download paths.
 
-Covers ``AI4DATA_METADATA_CATALOG_X_API_KEY`` (and host allow-list) being attached to:
+Covers ``AI4DATA_METADATA_CATALOG_X_API_KEY`` (and host allow-list) and
+``AI4DATA_METADATA_CATALOG_COOKIES`` being attached to:
+
 - :func:`ai4data.discovery.catalog.http.get_metadata_json`
 - :func:`ai4data.discovery.catalog.http.search_metadata`
 - :func:`ai4data.discovery.metadata.document_fetch.download_pdf`
 
-The header is host-scoped: arbitrary URLs only receive the key when the host matches the
-configured catalog host (or is allow-listed via ``x_api_key_hosts``).
+Both the header and the cookies are host-scoped: arbitrary URLs only receive them when the
+host matches the configured catalog host (or is allow-listed via ``x_api_key_hosts``).
 """
 
 from __future__ import annotations
@@ -26,18 +28,34 @@ from ai4data.discovery.metadata import document_fetch
 
 
 @contextlib.contextmanager
-def _override_catalog(*, url: str | None = None, x_api_key: str | None = None,
-                     x_api_key_hosts: str | None = None):
+def _override_catalog(
+    *,
+    url: str | None = None,
+    x_api_key: str | None = None,
+    x_api_key_hosts: str | None = None,
+    cookies: str | None = None,
+):
     """Temporarily mutate ``metadata_catalog`` for a test, restoring previous values."""
-    saved = (metadata_catalog.url, metadata_catalog.x_api_key, metadata_catalog.x_api_key_hosts)
+    saved = (
+        metadata_catalog.url,
+        metadata_catalog.x_api_key,
+        metadata_catalog.x_api_key_hosts,
+        metadata_catalog.cookies,
+    )
     if url is not None:
         metadata_catalog.url = url
     metadata_catalog.x_api_key = x_api_key
     metadata_catalog.x_api_key_hosts = x_api_key_hosts
+    metadata_catalog.cookies = cookies
     try:
         yield
     finally:
-        metadata_catalog.url, metadata_catalog.x_api_key, metadata_catalog.x_api_key_hosts = saved
+        (
+            metadata_catalog.url,
+            metadata_catalog.x_api_key,
+            metadata_catalog.x_api_key_hosts,
+            metadata_catalog.cookies,
+        ) = saved
 
 
 class _FakeResponse:
@@ -203,6 +221,184 @@ class TestDownloadPdfAttachesAuthHeader(_DiscoveryPathsTestCase):
                 )
         _, kwargs = mocked_get.call_args
         self.assertEqual(kwargs.get("headers"), {"x-api-key": "secret"})
+
+
+class TestParseCookieString(unittest.TestCase):
+    def test_none_returns_empty(self) -> None:
+        self.assertEqual(discovery_auth._parse_cookie_string(None), {})
+
+    def test_empty_string_returns_empty(self) -> None:
+        self.assertEqual(discovery_auth._parse_cookie_string(""), {})
+        self.assertEqual(discovery_auth._parse_cookie_string("   "), {})
+
+    def test_single_pair(self) -> None:
+        self.assertEqual(
+            discovery_auth._parse_cookie_string("ihsn_nada=abc123"),
+            {"ihsn_nada": "abc123"},
+        )
+
+    def test_multiple_pairs_with_spaces(self) -> None:
+        self.assertEqual(
+            discovery_auth._parse_cookie_string(
+                "ihsn_nada=abc123; ccsrf=deadbeef; ci_session=xyz"
+            ),
+            {"ihsn_nada": "abc123", "ccsrf": "deadbeef", "ci_session": "xyz"},
+        )
+
+    def test_value_with_equals_sign_preserved(self) -> None:
+        # Cookies may contain '=' in the value (e.g. base64); only split on the first '='.
+        self.assertEqual(
+            discovery_auth._parse_cookie_string("session=base64==value"),
+            {"session": "base64==value"},
+        )
+
+    def test_skips_segments_without_equals(self) -> None:
+        self.assertEqual(
+            discovery_auth._parse_cookie_string("ihsn_nada=abc; flagonly; ccsrf=def"),
+            {"ihsn_nada": "abc", "ccsrf": "def"},
+        )
+
+
+class TestGetCatalogCookies(unittest.TestCase):
+    def test_no_cookies_returns_empty(self) -> None:
+        with _override_catalog(cookies=None):
+            self.assertEqual(discovery_auth.get_catalog_cookies(), {})
+            self.assertEqual(
+                discovery_auth.get_catalog_cookies("https://anywhere.example/x.pdf"), {}
+            )
+
+    def test_cookies_without_url_are_sent_unconditionally(self) -> None:
+        # For catalog-only endpoints (search, JSON metadata) we always send cookies.
+        with _override_catalog(cookies="ihsn_nada=abc; ccsrf=def"):
+            self.assertEqual(
+                discovery_auth.get_catalog_cookies(),
+                {"ihsn_nada": "abc", "ccsrf": "def"},
+            )
+
+    def test_cookies_sent_for_matching_catalog_host(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php", cookies="ihsn_nada=abc"
+        ):
+            self.assertEqual(
+                discovery_auth.get_catalog_cookies(
+                    "https://catalog.example/index.php/catalog/1/download/2/file.pdf"
+                ),
+                {"ihsn_nada": "abc"},
+            )
+
+    def test_cookies_withheld_from_other_hosts(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php", cookies="ihsn_nada=abc"
+        ):
+            self.assertEqual(
+                discovery_auth.get_catalog_cookies("https://elsewhere.example/file.pdf"),
+                {},
+            )
+
+    def test_cookies_sent_for_allow_listed_host(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php",
+            x_api_key_hosts="training.ihsn.org",
+            cookies="ihsn_nada=abc; ccsrf=def",
+        ):
+            self.assertEqual(
+                discovery_auth.get_catalog_cookies(
+                    "https://training.ihsn.org/index.php/catalog/1/download/2/file.pdf"
+                ),
+                {"ihsn_nada": "abc", "ccsrf": "def"},
+            )
+
+    def test_relative_url_treated_as_catalog_local(self) -> None:
+        with _override_catalog(cookies="ihsn_nada=abc"):
+            self.assertEqual(
+                discovery_auth.get_catalog_cookies("/api/catalog/json/IDN-X"),
+                {"ihsn_nada": "abc"},
+            )
+
+
+class TestHttpAttachesCookies(_DiscoveryPathsTestCase):
+    def test_get_metadata_json_attaches_cookies_when_configured(self) -> None:
+        fake = _FakeResponse(payload={"type": "indicator"})
+        with _override_catalog(cookies="ihsn_nada=abc; ccsrf=def"):
+            with mock.patch.object(
+                catalog_http.httpx, "get", return_value=fake
+            ) as mocked_get:
+                catalog_http.get_metadata_json("IDN-COOK", "indicator")
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(
+            kwargs.get("cookies"), {"ihsn_nada": "abc", "ccsrf": "def"}
+        )
+
+    def test_get_metadata_json_omits_cookies_when_unconfigured(self) -> None:
+        fake = _FakeResponse(payload={"type": "indicator"})
+        with _override_catalog(cookies=None):
+            with mock.patch.object(
+                catalog_http.httpx, "get", return_value=fake
+            ) as mocked_get:
+                catalog_http.get_metadata_json("IDN-NOCOOK", "indicator")
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("cookies"), {})
+
+    def test_search_metadata_attaches_cookies_when_configured(self) -> None:
+        fake = _FakeResponse(payload={"result": {"rows": [], "found": 0}})
+        with _override_catalog(cookies="ihsn_nada=abc"):
+            with mock.patch.object(
+                catalog_http.httpx, "get", return_value=fake
+            ) as mocked_get:
+                catalog_http.search_metadata({"sk": "test"})
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("cookies"), {"ihsn_nada": "abc"})
+
+
+class TestDownloadPdfAttachesCookies(_DiscoveryPathsTestCase):
+    def test_download_pdf_attaches_cookies_to_catalog_host(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php",
+            cookies="ihsn_nada=abc; ccsrf=def",
+        ):
+            with mock.patch.object(
+                document_fetch.httpx,
+                "get",
+                return_value=_FakeResponse(content=_MIN_PDF),
+            ) as mocked_get:
+                document_fetch.download_pdf(
+                    "https://catalog.example/index.php/catalog/1/download/2/file.pdf"
+                )
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(
+            kwargs.get("cookies"), {"ihsn_nada": "abc", "ccsrf": "def"}
+        )
+
+    def test_download_pdf_withholds_cookies_from_third_party_host(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php",
+            cookies="ihsn_nada=abc",
+        ):
+            with mock.patch.object(
+                document_fetch.httpx,
+                "get",
+                return_value=_FakeResponse(content=_MIN_PDF),
+            ) as mocked_get:
+                document_fetch.download_pdf("https://third-party.example/file.pdf")
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("cookies"), {})
+
+    def test_download_pdf_uses_allow_listed_host_for_cookies(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php",
+            x_api_key_hosts="training.ihsn.org",
+            cookies="ihsn_nada=abc",
+        ):
+            with mock.patch.object(
+                document_fetch.httpx,
+                "get",
+                return_value=_FakeResponse(content=_MIN_PDF),
+            ) as mocked_get:
+                document_fetch.download_pdf(
+                    "https://training.ihsn.org/index.php/catalog/529/download/1293/file.pdf"
+                )
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("cookies"), {"ihsn_nada": "abc"})
 
 
 if __name__ == "__main__":

--- a/tests/test_discovery_auth.py
+++ b/tests/test_discovery_auth.py
@@ -1,0 +1,209 @@
+"""Tests for :mod:`ai4data.discovery.auth` and the auth-header wiring across catalog/HTTP
+and document download paths.
+
+Covers ``AI4DATA_METADATA_CATALOG_X_API_KEY`` (and host allow-list) being attached to:
+- :func:`ai4data.discovery.catalog.http.get_metadata_json`
+- :func:`ai4data.discovery.catalog.http.search_metadata`
+- :func:`ai4data.discovery.metadata.document_fetch.download_pdf`
+
+The header is host-scoped: arbitrary URLs only receive the key when the host matches the
+configured catalog host (or is allow-listed via ``x_api_key_hosts``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from ai4data.discovery import auth as discovery_auth
+from ai4data.discovery import paths as discovery_paths
+from ai4data.discovery.catalog import http as catalog_http
+from ai4data.discovery.config import metadata_catalog
+from ai4data.discovery.metadata import document_fetch
+
+
+@contextlib.contextmanager
+def _override_catalog(*, url: str | None = None, x_api_key: str | None = None,
+                     x_api_key_hosts: str | None = None):
+    """Temporarily mutate ``metadata_catalog`` for a test, restoring previous values."""
+    saved = (metadata_catalog.url, metadata_catalog.x_api_key, metadata_catalog.x_api_key_hosts)
+    if url is not None:
+        metadata_catalog.url = url
+    metadata_catalog.x_api_key = x_api_key
+    metadata_catalog.x_api_key_hosts = x_api_key_hosts
+    try:
+        yield
+    finally:
+        metadata_catalog.url, metadata_catalog.x_api_key, metadata_catalog.x_api_key_hosts = saved
+
+
+class _FakeResponse:
+    def __init__(self, content: bytes = b"", payload: dict | None = None,
+                 status_code: int = 200, headers: dict | None = None):
+        self.content = content
+        self._payload = payload
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload or {}
+
+
+_MIN_PDF = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+
+
+class TestGetCatalogAuthHeaders(unittest.TestCase):
+    def test_no_key_returns_empty(self) -> None:
+        with _override_catalog(x_api_key=None):
+            self.assertEqual(discovery_auth.get_catalog_auth_headers(), {})
+            self.assertEqual(
+                discovery_auth.get_catalog_auth_headers("https://anywhere.example/x.pdf"), {}
+            )
+
+    def test_key_without_url_is_sent_unconditionally(self) -> None:
+        # For catalog-only endpoints (search, JSON metadata) we always send the header.
+        with _override_catalog(x_api_key="secret"):
+            self.assertEqual(
+                discovery_auth.get_catalog_auth_headers(), {"x-api-key": "secret"}
+            )
+
+    def test_key_sent_for_matching_catalog_host(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php", x_api_key="secret"
+        ):
+            self.assertEqual(
+                discovery_auth.get_catalog_auth_headers(
+                    "https://catalog.example/index.php/catalog/1/download/2/file.pdf"
+                ),
+                {"x-api-key": "secret"},
+            )
+
+    def test_key_withheld_from_other_hosts(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php", x_api_key="secret"
+        ):
+            self.assertEqual(
+                discovery_auth.get_catalog_auth_headers(
+                    "https://elsewhere.example/file.pdf"
+                ),
+                {},
+            )
+
+    def test_key_sent_for_allow_listed_host(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php",
+            x_api_key="secret",
+            x_api_key_hosts="training.ihsn.org, files.ihsn.org",
+        ):
+            self.assertEqual(
+                discovery_auth.get_catalog_auth_headers(
+                    "https://training.ihsn.org/index.php/catalog/1/download/2/file.pdf"
+                ),
+                {"x-api-key": "secret"},
+            )
+            self.assertEqual(
+                discovery_auth.get_catalog_auth_headers(
+                    "https://files.ihsn.org/x.pdf"
+                ),
+                {"x-api-key": "secret"},
+            )
+
+    def test_relative_url_treated_as_catalog_local(self) -> None:
+        with _override_catalog(x_api_key="secret"):
+            self.assertEqual(
+                discovery_auth.get_catalog_auth_headers("/api/catalog/json/IDN-X"),
+                {"x-api-key": "secret"},
+            )
+
+
+class _DiscoveryPathsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        discovery_paths.init_discovery_paths(Path(self._tmpdir.name))
+        self.addCleanup(discovery_paths.init_discovery_paths, None)
+
+
+class TestHttpAttachesAuthHeader(_DiscoveryPathsTestCase):
+    def test_get_metadata_json_attaches_x_api_key_when_configured(self) -> None:
+        fake = _FakeResponse(payload={"type": "indicator"})
+        with _override_catalog(x_api_key="secret"):
+            with mock.patch.object(
+                catalog_http.httpx, "get", return_value=fake
+            ) as mocked_get:
+                catalog_http.get_metadata_json("IDN-AUTH", "indicator")
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("headers"), {"x-api-key": "secret"})
+
+    def test_get_metadata_json_omits_header_when_no_key(self) -> None:
+        fake = _FakeResponse(payload={"type": "indicator"})
+        with _override_catalog(x_api_key=None):
+            with mock.patch.object(
+                catalog_http.httpx, "get", return_value=fake
+            ) as mocked_get:
+                catalog_http.get_metadata_json("IDN-NOKEY", "indicator")
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("headers"), {})
+
+    def test_search_metadata_attaches_x_api_key_when_configured(self) -> None:
+        fake = _FakeResponse(payload={"result": {"rows": [], "found": 0}})
+        with _override_catalog(x_api_key="secret"):
+            with mock.patch.object(
+                catalog_http.httpx, "get", return_value=fake
+            ) as mocked_get:
+                catalog_http.search_metadata({"sk": "test"})
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("headers"), {"x-api-key": "secret"})
+
+
+class TestDownloadPdfAttachesAuthHeader(_DiscoveryPathsTestCase):
+    def test_download_pdf_attaches_x_api_key_to_catalog_host(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php", x_api_key="secret"
+        ):
+            with mock.patch.object(
+                document_fetch.httpx, "get", return_value=_FakeResponse(content=_MIN_PDF)
+            ) as mocked_get:
+                document_fetch.download_pdf(
+                    "https://catalog.example/index.php/catalog/1/download/2/file.pdf"
+                )
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("headers"), {"x-api-key": "secret"})
+
+    def test_download_pdf_withholds_x_api_key_from_third_party_host(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php", x_api_key="secret"
+        ):
+            with mock.patch.object(
+                document_fetch.httpx, "get", return_value=_FakeResponse(content=_MIN_PDF)
+            ) as mocked_get:
+                document_fetch.download_pdf(
+                    "https://third-party.example/file.pdf"
+                )
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("headers"), {})
+
+    def test_download_pdf_uses_allow_listed_host(self) -> None:
+        with _override_catalog(
+            url="https://catalog.example/index.php",
+            x_api_key="secret",
+            x_api_key_hosts="training.ihsn.org",
+        ):
+            with mock.patch.object(
+                document_fetch.httpx, "get", return_value=_FakeResponse(content=_MIN_PDF)
+            ) as mocked_get:
+                document_fetch.download_pdf(
+                    "https://training.ihsn.org/index.php/catalog/529/download/1293/file.pdf"
+                )
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("headers"), {"x-api-key": "secret"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discovery_document_fetch.py
+++ b/tests/test_discovery_document_fetch.py
@@ -1,0 +1,145 @@
+"""Tests for :mod:`ai4data.discovery.metadata.document_fetch`.
+
+Covers the IHSN / NADA failure mode where the catalog returns ``200 OK`` with a 0-byte body
+and a ``Refresh: 0;url=.../auth/login/...`` header for documents that require authentication.
+Without validation, ``cache_download_pdf`` would persist that empty body and short-circuit on
+every subsequent call (``fpath.exists()`` is True), so ``load_pdf`` always failed with
+"Cannot open empty file" and the document was silently skipped.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from ai4data.discovery import paths as discovery_paths
+from ai4data.discovery.metadata import document_fetch
+
+
+class _FakeResponse:
+    """Minimal stand-in for :class:`httpx.Response`."""
+
+    def __init__(self, content: bytes, status_code: int = 200, headers: dict | None = None):
+        self.content = content
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+_MIN_PDF = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+
+
+class _DocumentFetchTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.tmp_root = Path(self._tmpdir.name)
+        discovery_paths.init_discovery_paths(self.tmp_root)
+        self.addCleanup(discovery_paths.init_discovery_paths, None)
+
+
+class TestDownloadPdf(_DocumentFetchTestCase):
+    def test_valid_pdf_returns_bytes(self) -> None:
+        with mock.patch.object(
+            document_fetch.httpx, "get", return_value=_FakeResponse(_MIN_PDF)
+        ):
+            content = document_fetch.download_pdf("https://example.test/doc.pdf")
+        self.assertEqual(content, _MIN_PDF)
+
+    def test_empty_body_raises_empty_download_error(self) -> None:
+        with mock.patch.object(
+            document_fetch.httpx, "get", return_value=_FakeResponse(b"")
+        ):
+            with self.assertRaises(document_fetch.EmptyDownloadError):
+                document_fetch.download_pdf("https://example.test/doc.pdf")
+
+    def test_empty_body_with_login_refresh_header_surfaces_hint(self) -> None:
+        # Reproduces the IHSN / NADA login-wall response observed in production:
+        # 200 OK, content-length 0, Refresh: 0;url=.../auth/login/...
+        refresh = (
+            "0;url=https://training.ihsn.org/index.php/auth/login/?destination=..."
+        )
+        with mock.patch.object(
+            document_fetch.httpx,
+            "get",
+            return_value=_FakeResponse(b"", headers={"refresh": refresh}),
+        ):
+            with self.assertRaises(document_fetch.EmptyDownloadError) as ctx:
+                document_fetch.download_pdf("https://example.test/doc.pdf")
+        self.assertIn("login", str(ctx.exception).lower())
+
+    def test_non_pdf_body_raises_empty_download_error(self) -> None:
+        with mock.patch.object(
+            document_fetch.httpx,
+            "get",
+            return_value=_FakeResponse(b"<html>Login required</html>"),
+        ):
+            with self.assertRaises(document_fetch.EmptyDownloadError):
+                document_fetch.download_pdf("https://example.test/doc.pdf")
+
+
+class TestCacheDownloadPdf(_DocumentFetchTestCase):
+    def test_writes_pdf_and_returns_path(self) -> None:
+        with mock.patch.object(
+            document_fetch.httpx, "get", return_value=_FakeResponse(_MIN_PDF)
+        ) as mocked_get:
+            fpath = document_fetch.cache_download_pdf(
+                "https://example.test/doc.pdf", "IDN-OK", "document"
+            )
+        self.assertTrue(fpath.exists())
+        self.assertGreater(fpath.stat().st_size, 0)
+        self.assertEqual(fpath.read_bytes(), _MIN_PDF)
+        mocked_get.assert_called_once()
+
+    def test_existing_zero_byte_cache_is_discarded_and_redownloaded(self) -> None:
+        # Simulate the legacy bug: an earlier run cached an empty body. The next call should
+        # NOT short-circuit on `fpath.exists()`; it should drop the stale file and re-fetch.
+        fpath = discovery_paths.get_document_cache_path("IDN-EMPTY", "document")
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        fpath.write_bytes(b"")
+        self.assertEqual(fpath.stat().st_size, 0)
+
+        with mock.patch.object(
+            document_fetch.httpx, "get", return_value=_FakeResponse(_MIN_PDF)
+        ) as mocked_get:
+            result = document_fetch.cache_download_pdf(
+                "https://example.test/doc.pdf", "IDN-EMPTY", "document"
+            )
+
+        self.assertEqual(result, fpath)
+        self.assertEqual(fpath.read_bytes(), _MIN_PDF)
+        mocked_get.assert_called_once()
+
+    def test_existing_non_empty_cache_is_reused(self) -> None:
+        fpath = discovery_paths.get_document_cache_path("IDN-CACHED", "document")
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        fpath.write_bytes(_MIN_PDF)
+
+        with mock.patch.object(document_fetch.httpx, "get") as mocked_get:
+            result = document_fetch.cache_download_pdf(
+                "https://example.test/doc.pdf", "IDN-CACHED", "document"
+            )
+
+        self.assertEqual(result, fpath)
+        mocked_get.assert_not_called()
+
+    def test_empty_response_does_not_persist_zero_byte_file(self) -> None:
+        # The previous implementation happily wrote `b""` to disk on a 200/empty response,
+        # poisoning the cache. The hardened version must raise before touching the file.
+        with mock.patch.object(
+            document_fetch.httpx, "get", return_value=_FakeResponse(b"")
+        ):
+            with self.assertRaises(ValueError):
+                document_fetch.cache_download_pdf(
+                    "https://example.test/doc.pdf", "IDN-AUTH", "document"
+                )
+        fpath = discovery_paths.get_document_cache_path("IDN-AUTH", "document")
+        self.assertFalse(fpath.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discovery_include_resources.py
+++ b/tests/test_discovery_include_resources.py
@@ -1,0 +1,291 @@
+"""Tests for the ``include_resources`` plumbing across discovery paths, HTTP, and loader.
+
+Covers the changes that thread an ``include_resources`` flag from
+:class:`ai4data.discovery.metadata.handler.MetadataLoader` through
+:func:`ai4data.discovery.catalog.http.get_metadata_json` into the cache filename
+chosen by :func:`ai4data.discovery.paths.get_metadata_cache_path`.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from ai4data.discovery import paths as discovery_paths
+from ai4data.discovery.catalog import http as catalog_http
+from ai4data.discovery.metadata import handler as metadata_handler
+
+
+class _FakeResponse:
+    """Minimal stand-in for :class:`httpx.Response` used in cache-miss tests."""
+
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _DiscoveryPathsTestCase(unittest.TestCase):
+    """Base class that redirects discovery caches to a per-test temp dir."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.tmp_root = Path(self._tmpdir.name)
+        discovery_paths.init_discovery_paths(self.tmp_root)
+        self.addCleanup(discovery_paths.init_discovery_paths, None)
+
+
+class TestGetMetadataCachePath(_DiscoveryPathsTestCase):
+    def test_default_filename_omits_resources_suffix(self):
+        path = discovery_paths.get_metadata_cache_path("IDN-001", "indicator")
+        self.assertEqual(path.name, "indicator_IDN-001.json")
+        self.assertEqual(path.parent, self.tmp_root / "metadata_cache" / "indicator")
+
+    def test_include_resources_false_matches_default(self):
+        default = discovery_paths.get_metadata_cache_path("IDN-001", "indicator")
+        explicit_false = discovery_paths.get_metadata_cache_path(
+            "IDN-001", "indicator", include_resources=False
+        )
+        self.assertEqual(default, explicit_false)
+
+    def test_include_resources_true_uses_res_suffix(self):
+        path = discovery_paths.get_metadata_cache_path(
+            "IDN-001", "indicator", include_resources=True
+        )
+        self.assertEqual(path.name, "indicator_IDN-001.res.json")
+        self.assertEqual(path.parent, self.tmp_root / "metadata_cache" / "indicator")
+
+    def test_resource_and_default_paths_are_distinct(self):
+        default = discovery_paths.get_metadata_cache_path("IDN-001", "indicator")
+        with_res = discovery_paths.get_metadata_cache_path(
+            "IDN-001", "indicator", include_resources=True
+        )
+        self.assertNotEqual(default, with_res)
+
+    def test_parent_directory_is_created(self):
+        path = discovery_paths.get_metadata_cache_path(
+            "IDN-001", "document", include_resources=True
+        )
+        self.assertTrue(path.parent.exists())
+        self.assertTrue(path.parent.is_dir())
+
+
+class TestGetMetadataJson(_DiscoveryPathsTestCase):
+    def test_cache_hit_short_circuits_http(self):
+        idno = "IDN-CACHED"
+        metadata_type = "indicator"
+        cache_path = discovery_paths.get_metadata_cache_path(idno, metadata_type)
+        cached_payload = {"idno": idno, "type": metadata_type, "from": "cache"}
+        cache_path.write_text(json.dumps(cached_payload), encoding="utf-8")
+
+        with mock.patch.object(catalog_http.httpx, "get") as mocked_get:
+            result = catalog_http.get_metadata_json(idno, metadata_type)
+
+        self.assertEqual(result, cached_payload)
+        mocked_get.assert_not_called()
+
+    def test_force_bypasses_cache_and_fetches(self):
+        idno = "IDN-FORCE"
+        metadata_type = "indicator"
+        cache_path = discovery_paths.get_metadata_cache_path(idno, metadata_type)
+        cache_path.write_text(json.dumps({"stale": True}), encoding="utf-8")
+
+        fresh_payload = {"type": "indicator", "fresh": True}
+        with mock.patch.object(
+            catalog_http.httpx, "get", return_value=_FakeResponse(fresh_payload)
+        ) as mocked_get:
+            result = catalog_http.get_metadata_json(
+                idno, metadata_type, force=True
+            )
+
+        self.assertEqual(result, fresh_payload)
+        mocked_get.assert_called_once()
+        on_disk = json.loads(cache_path.read_text(encoding="utf-8"))
+        self.assertEqual(on_disk, fresh_payload)
+
+    def test_load_exists_false_returns_none_on_cache_hit(self):
+        idno = "IDN-SKIPLOAD"
+        metadata_type = "indicator"
+        cache_path = discovery_paths.get_metadata_cache_path(idno, metadata_type)
+        cache_path.write_text(json.dumps({"any": "value"}), encoding="utf-8")
+
+        with mock.patch.object(catalog_http.httpx, "get") as mocked_get:
+            result = catalog_http.get_metadata_json(
+                idno, metadata_type, load_exists=False
+            )
+
+        self.assertIsNone(result)
+        mocked_get.assert_not_called()
+
+    def test_cache_miss_passes_include_resources_false_query_param(self):
+        idno = "IDN-NEW"
+        metadata_type = "indicator"
+        fake_response = _FakeResponse({"type": "indicator", "from": "http"})
+
+        with mock.patch.object(
+            catalog_http.httpx, "get", return_value=fake_response
+        ) as mocked_get:
+            result = catalog_http.get_metadata_json(idno, metadata_type)
+
+        self.assertEqual(result["from"], "http")
+        mocked_get.assert_called_once()
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("params"), {"include_resources": False})
+
+        cache_path = discovery_paths.get_metadata_cache_path(idno, metadata_type)
+        self.assertTrue(cache_path.exists())
+        self.assertEqual(
+            json.loads(cache_path.read_text(encoding="utf-8")),
+            {"type": "indicator", "from": "http"},
+        )
+
+    def test_cache_miss_passes_include_resources_true_query_param(self):
+        idno = "IDN-RES"
+        metadata_type = "indicator"
+        fake_response = _FakeResponse(
+            {"type": "indicator", "resources": [{"id": 1}]}
+        )
+
+        with mock.patch.object(
+            catalog_http.httpx, "get", return_value=fake_response
+        ) as mocked_get:
+            catalog_http.get_metadata_json(
+                idno, metadata_type, include_resources=True
+            )
+
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("params"), {"include_resources": True})
+
+        res_path = discovery_paths.get_metadata_cache_path(
+            idno, metadata_type, include_resources=True
+        )
+        default_path = discovery_paths.get_metadata_cache_path(idno, metadata_type)
+        self.assertTrue(res_path.exists())
+        self.assertFalse(default_path.exists())
+
+    def test_include_resources_cache_paths_are_independent(self):
+        idno = "IDN-SPLIT"
+        metadata_type = "indicator"
+
+        default_payload = {"type": "indicator", "variant": "no-res"}
+        res_payload = {"type": "indicator", "variant": "with-res"}
+
+        with mock.patch.object(
+            catalog_http.httpx,
+            "get",
+            side_effect=[_FakeResponse(default_payload), _FakeResponse(res_payload)],
+        ) as mocked_get:
+            first = catalog_http.get_metadata_json(idno, metadata_type)
+            second = catalog_http.get_metadata_json(
+                idno, metadata_type, include_resources=True
+            )
+
+        self.assertEqual(first["variant"], "no-res")
+        self.assertEqual(second["variant"], "with-res")
+        self.assertEqual(mocked_get.call_count, 2)
+
+        with mock.patch.object(catalog_http.httpx, "get") as mocked_get_after:
+            cached_default = catalog_http.get_metadata_json(idno, metadata_type)
+            cached_res = catalog_http.get_metadata_json(
+                idno, metadata_type, include_resources=True
+            )
+
+        mocked_get_after.assert_not_called()
+        self.assertEqual(cached_default["variant"], "no-res")
+        self.assertEqual(cached_res["variant"], "with-res")
+
+    def test_timeseries_type_is_normalized_to_indicator(self):
+        with mock.patch.object(
+            catalog_http.httpx,
+            "get",
+            return_value=_FakeResponse({"type": "timeseries"}),
+        ):
+            result = catalog_http.get_metadata_json("IDN-TS", "indicator")
+        self.assertEqual(result["type"], "indicator")
+
+    def test_survey_type_is_normalized_to_microdata(self):
+        with mock.patch.object(
+            catalog_http.httpx,
+            "get",
+            return_value=_FakeResponse({"type": "survey"}),
+        ):
+            result = catalog_http.get_metadata_json("IDN-SV", "microdata")
+        self.assertEqual(result["type"], "microdata")
+
+    def test_type_mismatch_raises_assertion_error(self):
+        with mock.patch.object(
+            catalog_http.httpx,
+            "get",
+            return_value=_FakeResponse({"type": "document"}),
+        ):
+            with self.assertRaises(AssertionError):
+                catalog_http.get_metadata_json("IDN-X", "indicator")
+
+    def test_no_metadata_type_skips_cache_layer(self):
+        fake_response = _FakeResponse({"type": "indicator"})
+        with mock.patch.object(
+            catalog_http.httpx, "get", return_value=fake_response
+        ) as mocked_get:
+            result = catalog_http.get_metadata_json("IDN-NOTYPE")
+
+        self.assertEqual(result, {"type": "indicator"})
+        _, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get("params"), {"include_resources": False})
+        listed = list((self.tmp_root / "metadata_cache").rglob("*.json"))
+        self.assertEqual(listed, [])
+
+
+class TestMetadataLoaderIncludeResources(_DiscoveryPathsTestCase):
+    def test_default_include_resources_is_false(self):
+        with mock.patch.object(
+            metadata_handler,
+            "get_metadata_json",
+            return_value={"type": "indicator"},
+        ) as mocked:
+            loader = metadata_handler.MetadataLoader(
+                idno="IDN-LOAD", metadata_type="indicator"
+            )
+
+        self.assertFalse(loader.include_resources)
+        mocked.assert_called_once_with(
+            "IDN-LOAD",
+            "indicator",
+            force=False,
+            include_resources=False,
+        )
+        self.assertEqual(loader.metadata["idno"], "IDN-LOAD")
+
+    def test_include_resources_true_is_forwarded(self):
+        with mock.patch.object(
+            metadata_handler,
+            "get_metadata_json",
+            return_value={"type": "indicator", "resources": []},
+        ) as mocked:
+            loader = metadata_handler.MetadataLoader(
+                idno="IDN-LOAD-RES",
+                metadata_type="indicator",
+                force=True,
+                include_resources=True,
+            )
+
+        self.assertTrue(loader.include_resources)
+        mocked.assert_called_once_with(
+            "IDN-LOAD-RES",
+            "indicator",
+            force=True,
+            include_resources=True,
+        )
+        self.assertEqual(loader.metadata["idno"], "IDN-LOAD-RES")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds a **standalone discovery subsystem** under `ai4data.discovery`, installable via the **`discovery`** optional extra (`pip install "ai4data[discovery]"` / `uv sync --extra discovery`). It is intended for **NADA-style** workflows: talking to the NADA catalog, normalizing and templating metadata into searchable text, optional document handling, and **embedding-related helpers** for downstream search or clustering.

**What is included**

- **Catalog client**: HTTP utilities, batch helpers, and thin wrappers around catalog/search APIs (`discovery/catalog/`).
- **Metadata pipeline**: handlers, filters, parsers, Jinja templates for `page_content` by record type, and related utilities (`discovery/metadata/`).
- **Configuration and paths**: discovery-specific settings, env-driven data/cache paths, and wiring for consumers (`discovery/config.py`, `paths.py`, `wiring.py`).
- **Embeddings**: new modules under `discovery/` for embedding workflows used by discovery or callers (see `embeddings.py`, `semantic_cluster_embedding.py`, and related imports).
- **Documentation**: README files under discovery subpackages describing usage and layout.
- **`pyproject.toml`**: declares the **`discovery`** extra with its dependency set (httpx, pydantic, Jinja2, sentence-transformers, torch, document stack pieces, etc.).

**Consumer note**

Downstream projects (for example **nada-ai**) can pin this revision and depend on **`ai4data[discovery]`** for catalog + metadata fetch without vendoring a monorepo copy of discovery.

**How to verify locally**

```bash
uv sync --extra discovery
# smoke: import discovery subpackages and run any existing discovery tests you add in CI
python -c "from ai4data.discovery import catalog, metadata; print('ok')"
```