### PR TITLE
feat(augmentation): DDI variable group curation, QA agent, and parallel LLM generation

### DIFF
--- a/docs/inclusive-ai/inclusive-ai.md
+++ b/docs/inclusive-ai/inclusive-ai.md
@@ -22,7 +22,7 @@ Not all tasks require the most powerful (and most expensive) LLM. Many data qual
 | Multi-step data analysis | Large (Claude Opus, GPT-4) | Complex reasoning, long context |
 | Classification with schema | Small–Medium | Structured output reduces hallucination risk |
 
-The ai4data project defaults to efficient models where appropriate. For example, `DataDictionaryAugmentor` defaults to `claude-haiku-4-5-20251001` for theme generation—a fast, cost-effective choice for short, structured outputs. The model can be overridden for tasks requiring more reasoning depth.
+The ai4data project defaults to efficient models where appropriate. For example, `DataDictionaryAugmentor` defaults to `claude-haiku-4-5-20251001` for variable group curation—a fast, cost-effective choice for short, structured outputs. The model can be overridden for tasks requiring more reasoning depth.
 
 ### Batch Processing
 

--- a/docs/inclusive-ai/inclusive-ai.md
+++ b/docs/inclusive-ai/inclusive-ai.md
@@ -22,7 +22,7 @@ Not all tasks require the most powerful (and most expensive) LLM. Many data qual
 | Multi-step data analysis | Large (Claude Opus, GPT-4) | Complex reasoning, long context |
 | Classification with schema | Small–Medium | Structured output reduces hallucination risk |
 
-The ai4data project defaults to efficient models where appropriate. For example, `DataDictionaryAugmentor` defaults to `claude-haiku-4-5-20251001` for variable group curation—a fast, cost-effective choice for short, structured outputs. The model can be overridden for tasks requiring more reasoning depth.
+The ai4data project defaults to capable models where appropriate. For example, `DataDictionaryAugmentor` defaults to `claude-sonnet-4-6` for variable group curation and self-consistency QA. The model can be overridden independently for curation (`model`) and QA (`qa_model`) to balance cost and quality.
 
 ### Batch Processing
 

--- a/docs/metadata-augmentation/index.md
+++ b/docs/metadata-augmentation/index.md
@@ -1,6 +1,6 @@
 # Metadata Augmentation Methodology
 
-This section describes the methodology implemented by the World Bank's Development Data Group for **automatically generating thematic structure** for data dictionary variables in microdata and administrative datasets. The approach uses semantic clustering and LLM-elicited theme names to organize hundreds or thousands of survey variables into meaningful thematic groups—without manual labeling.
+This section describes the methodology implemented by the World Bank's Development Data Group for **automatically generating DDI-style variable groups** for data dictionary variables in microdata and administrative datasets. The approach uses semantic clustering and LLM-elicited curation to organize hundreds or thousands of survey variables into meaningful groups—without manual labeling.
 
 The methodology is implemented in the `ai4data.metadata.augmentation` package. A step-by-step notebook is provided: Microdata Theme Generation with LLMs.
 
@@ -36,11 +36,11 @@ Each variable is encoded as a dense numerical vector using a sentence-transforme
 **Step 3. Clustering into semantic groups**
 Variables are grouped using Agglomerative Clustering (Ward linkage). The number of clusters is either specified by the user or estimated automatically using silhouette score optimization. A post-processing step ensures that each cluster's variable list fits within the LLM context window.
 
-**Step 4. Generating theme names with an LLM**
-For each cluster, the pipeline calls an LLM (Claude, OpenAI, or Gemini via litellm) and asks it to generate a concise theme name (2–6 words) and a 1–2 sentence description grounded in the variable labels. The LLM output is structured JSON, validated against a Pydantic schema.
+**Step 4. Curating variable groups with an LLM**
+For each cluster, the pipeline calls an LLM (Claude, OpenAI, or Gemini via litellm) and asks it to curate a DDI-style variable group: select the variables that belong, and produce a label, description, definition, and optional universe/notes. The LLM output is structured JSON, validated against a Pydantic schema. Deterministic fields (`vgid`, `group_type`, `variable_groups`) are assembled by the framework.
 
 **Step 5. Assembling and exporting the augmented dictionary**
-The generated themes and variable-to-theme assignments are assembled into an `AugmentedDictionary` object that can be exported to JSON or converted to a pandas DataFrame for further use.
+The generated variable groups and curated variable assignments are assembled into an `AugmentedDictionary` object that can be exported to JSON or converted to a pandas DataFrame for further use.
 
 ---
 
@@ -74,9 +74,10 @@ result = augmentor.augment("data_dictionary.csv")
 augmentor.export("augmented_dictionary.json")
 
 # Inspect results
-for theme in result.themes:
-    print(f"{theme.theme_name}: {theme.description}")
-    print(f"  Examples: {', '.join(theme.example_variables[:3])}")
+for group in result.variable_groups:
+    print(f"{group.vgid}: {group.label}")
+    print(f"  {group.txt}")
+    print(f"  Variables: {group.variables}")
     print()
 ```
 
@@ -105,7 +106,7 @@ result = (
     .load("custom_dictionary.csv", adapter=adapter)
     .embed(show_progress_bar=True)
     .cluster()
-    .generate_themes()
+    .generate_variable_groups()
 )
 
 # Export to DataFrame

--- a/docs/metadata-augmentation/index.md
+++ b/docs/metadata-augmentation/index.md
@@ -39,6 +39,9 @@ Variables are grouped using Agglomerative Clustering (Ward linkage). The number 
 **Step 4. Curating variable groups with an LLM**
 For each cluster, the pipeline calls an LLM (Claude, OpenAI, or Gemini via litellm) and asks it to curate a DDI-style variable group: select the variables that belong, and produce a label, description, definition, and optional universe/notes. The LLM output is structured JSON, validated against a Pydantic schema. Deterministic fields (`vgid`, `group_type`, `variable_groups`) are assembled by the framework.
 
+**Step 4b. Self-consistency QA**
+After curation, a second LLM call (the QA agent) assesses whether the label, description, definition, and selected variables are mutually coherent. Groups that fail QA are flagged (`qa_passed=False`) but kept in the output for human review.
+
 **Step 5. Assembling and exporting the augmented dictionary**
 The generated variable groups and curated variable assignments are assembled into an `AugmentedDictionary` object that can be exported to JSON or converted to a pandas DataFrame for further use.
 
@@ -75,10 +78,14 @@ augmentor.export("augmented_dictionary.json")
 
 # Inspect results
 for group in result.variable_groups:
-    print(f"{group.vgid}: {group.label}")
+    print(f"{group.vgid}: {group.label} (qa_passed={group.qa_passed})")
     print(f"  {group.txt}")
     print(f"  Variables: {group.variables}")
     print()
+
+# Filter groups that failed self-consistency QA
+failed = [g for g in result.variable_groups if g.qa_passed is False]
+print(f"{len(failed)} groups failed QA")
 ```
 
 Step-by-step usage with custom settings:

--- a/docs/metadata-augmentation/methodology.md
+++ b/docs/metadata-augmentation/methodology.md
@@ -131,17 +131,17 @@ The silhouette score measures how similar each point is to its own cluster relat
 
 ### Token Budget Enforcement
 
-After clustering, a post-hoc merge step ensures that no cluster's variable list exceeds the LLM context budget:
+After clustering, a post-hoc split step ensures that no cluster's variable list exceeds the LLM context budget:
 
 ```python
 from ai4data.metadata.augmentation.clustering import merge_clusters_for_token_budget
 
 labels = merge_clusters_for_token_budget(
-    labels, variables, max_tokens_per_cluster=450
+    labels, variables, max_tokens_per_cluster=2048
 )
 ```
 
-The merge splits oversized clusters by halving them iteratively. Token count per cluster is estimated conservatively (10 tokens per variable by default). This ensures every LLM call receives a variable list that fits within the context window without truncation.
+Oversized clusters are split by moving the minimum number of trailing variables into a new cluster until the remainder fits the budget; the process repeats iteratively. Token count per cluster is estimated conservatively (10 tokens per variable by default). This ensures every LLM call receives a variable list that fits within the context window without truncation.
 
 ---
 

--- a/docs/metadata-augmentation/methodology.md
+++ b/docs/metadata-augmentation/methodology.md
@@ -241,9 +241,15 @@ augmentor = DataDictionaryAugmentor(
 
 # Disable QA
 augmentor = DataDictionaryAugmentor(enable_qa=False)
+
+# Parallel cluster generation (default max_concurrency=1 is sequential)
+augmentor = DataDictionaryAugmentor(max_concurrency=5)
+result = augmentor.augment("variables.csv", max_concurrency=5)
 ```
 
-Run metadata records `qa_model`, `enable_qa`, `n_qa_passed`, `n_qa_failed`, and `n_qa_skipped`.
+`max_concurrency` controls how many clusters are processed in parallel during LLM generation. It can be set on the constructor, overridden per run via `generate_variable_groups(max_concurrency=N)` or `augment(max_concurrency=N)`. Defaults to `1` (sequential). Higher values reduce wall-clock time but may trigger provider rate limits — tune to your API tier.
+
+Run metadata records `qa_model`, `enable_qa`, `n_qa_passed`, `n_qa_failed`, `n_qa_skipped`, and `max_concurrency`.
 
 ### QA failure behavior
 

--- a/docs/metadata-augmentation/methodology.md
+++ b/docs/metadata-augmentation/methodology.md
@@ -200,13 +200,65 @@ Validation via `VariableGroupCurationResult.from_llm_response(content, candidate
 
 Structured output enforcement uses the provider's JSON Schema API when available (`response_format={"type": "json_schema", ...}`), falling back to `{"type": "json_object"}` for providers that don't support strict schema.
 
+---
+
+## Step 4b: Self-Consistency QA Agent
+
+Implemented in [`qa.py`](../../src/ai4data/metadata/augmentation/qa.py).
+
+After curation, the pipeline optionally runs a **QA agent** — a second LLM call that assesses whether the proposed group's parts are mutually coherent (self-consistency prompting). This catches cases where the label, description, or definition do not match the selected variables.
+
+### Manuscript mapping
+
+| Manuscript concept | DDI field | QA checks |
+|---|---|---|
+| Theme name | `label` | Aligns with txt and variable labels |
+| Description | `txt` | Describes selected variables, not unrelated concepts |
+| Examples | `variables` (+ input labels) | Support the stated label |
+| Grouping rationale | `definition` | Matches label and selected variables |
+
+### QA output schema
+
+```python
+class VariableGroupQAResult(StrictBaseModel):
+    is_self_consistent: bool
+    rationale: str = ""
+```
+
+Results are stored on each `VariableGroup` as `qa_passed` and `qa_rationale`. When QA is disabled, `qa_passed` is `None`.
+
+### Configuration
+
+```python
+# Default: curation and QA both use claude-sonnet-4-6
+augmentor = DataDictionaryAugmentor()
+
+# Cost tradeoff: cheaper curation, Sonnet QA
+augmentor = DataDictionaryAugmentor(
+    model="gpt-4o-mini",
+    qa_model="claude-sonnet-4-6",
+)
+
+# Disable QA
+augmentor = DataDictionaryAugmentor(enable_qa=False)
+```
+
+Run metadata records `qa_model`, `enable_qa`, `n_qa_passed`, `n_qa_failed`, and `n_qa_skipped`.
+
+### QA failure behavior
+
+- **Inconsistent curation** (`qa_passed=False`): curation output is kept; assignments are still emitted; rationale explains the inconsistency.
+- **QA call failure** (`qa_passed=None`): curation output is kept; `qa_rationale` is `"QA call failed"`.
+
+---
+
 ### LLM Provider Configuration (via litellm)
 
 The pipeline uses [litellm](https://docs.litellm.ai/) for provider-agnostic LLM calls. Any litellm-supported model string works:
 
 ```python
 # Anthropic Claude (default)
-augmentor = DataDictionaryAugmentor(model="claude-haiku-4-5-20251001")
+augmentor = DataDictionaryAugmentor(model="claude-sonnet-4-6")
 
 # OpenAI
 augmentor = DataDictionaryAugmentor(model="gpt-4o-mini")
@@ -257,6 +309,8 @@ class VariableGroup(StrictBaseModel):
     txt: str
     definition: str
     cluster_id: int
+    qa_passed: Optional[bool] = None
+    qa_rationale: str = ""
 
 class VariableGroupAssignment(StrictBaseModel):
     variable_name: str

--- a/docs/metadata-augmentation/methodology.md
+++ b/docs/metadata-augmentation/methodology.md
@@ -134,9 +134,9 @@ The silhouette score measures how similar each point is to its own cluster relat
 After clustering, a post-hoc split step ensures that no cluster's variable list exceeds the LLM context budget:
 
 ```python
-from ai4data.metadata.augmentation.clustering import merge_clusters_for_token_budget
+from ai4data.metadata.augmentation.clustering import split_clusters_for_token_budget
 
-labels = merge_clusters_for_token_budget(
+labels = split_clusters_for_token_budget(
     labels, variables, max_tokens_per_cluster=2048
 )
 ```

--- a/docs/metadata-augmentation/methodology.md
+++ b/docs/metadata-augmentation/methodology.md
@@ -145,22 +145,23 @@ The merge splits oversized clusters by halving them iteratively. Token count per
 
 ---
 
-## Step 4: LLM Theme Generation
+## Step 4: LLM Variable Group Curation
 
 Implemented in [`prompts.py`](../../src/ai4data/metadata/augmentation/prompts.py) and [`augmentor.py`](../../src/ai4data/metadata/augmentation/augmentor.py).
 
 ### Prompt Design
 
 **System prompt** establishes the task and constraints:
-- Role: "data catalog specialist for social science and development datasets"
-- Goal: generate theme name, description, example variables
-- Constraints: 2–6 word title-case theme name, 1–2 sentence description, up to 5 variable names from the INPUT list only
+- Role: expert metadata curator for social science and development datasets
+- Goal: curate one DDI-style variable group from candidate variables (may be a subset)
+- LLM-generated fields: `label`, `universe`, `notes`, `txt`, `definition`, `variables` (JSON array)
+- Constraints: 2–6 word title-case label, catalog-style description, include all variables that fit (no artificial cap; cluster token budget is the practical limit)
 - Output: valid JSON only, no markdown or extra text
 
 **User prompt** renders the numbered variable list:
 ```
 # TASK
-Generate a theme name and description for the following cluster of survey variables.
+Create one DDI-style variable group from the following candidate variables.
 
 # VARIABLES
 1. HV001: Cluster number
@@ -168,19 +169,34 @@ Generate a theme name and description for the following cluster of survey variab
 3. HV003: Respondent's line number
 ...
 
-Output ONLY valid JSON matching the schema.
+Return ONLY valid JSON matching the required schema.
 ```
+
+### LLM vs Deterministic Fields
+
+| Field | Source |
+|-------|--------|
+| `label`, `universe`, `notes`, `txt`, `definition`, `variables` | LLM |
+| `vgid` | Deterministic (`make_vgid(label, cluster_id)`) |
+| `variable_groups` | Always `""` |
+| `group_type` | Always `"subject"` |
+| `variables` (space-separated string) | Framework joins validated LLM array |
 
 ### Structured Output Schema
 
-The LLM response is validated against `ThemeGenerationResult`:
+The LLM response is validated against `VariableGroupCurationResult`:
 
 ```python
-class ThemeGenerationResult(StrictBaseModel):
-    theme_name: str        # e.g., "Household Identification"
-    description: str       # e.g., "Variables identifying survey clusters and households."
-    example_variables: List[str]  # e.g., ["HV001", "HV002", "HV003"]
+class VariableGroupCurationResult(StrictBaseModel):
+    label: str
+    universe: str = ""
+    notes: str = ""
+    txt: str
+    definition: str
+    variables: List[str]  # min 1; all names must exist in candidate set
 ```
+
+Validation via `VariableGroupCurationResult.from_llm_response(content, candidate_names=...)` rejects duplicate names and any variable not in the cluster candidate set. The full DDI record is assembled by `VariableGroup.from_curation()`.
 
 Structured output enforcement uses the provider's JSON Schema API when available (`response_format={"type": "json_schema", ...}`), falling back to `{"type": "json_object"}` for providers that don't support strict schema.
 
@@ -211,7 +227,7 @@ export GEMINI_API_KEY="..."
 
 ### Error Handling
 
-Each cluster call is wrapped in a try/except. If the LLM call fails or the response cannot be parsed, the cluster receives a fallback theme ("Uncategorized") and execution continues. This ensures partial results are always returned even when individual calls fail—important for large dictionaries where one API error should not abort the entire run.
+Each cluster call is wrapped in a try/except. If the LLM call fails, the response cannot be parsed, or variable validation fails, the cluster receives a fallback variable group (`VG_UNCATEGORIZED_{cluster_id}`) and execution continues. This ensures partial results are always returned even when individual calls fail—important for large dictionaries where one API error should not abort the entire run.
 
 ---
 
@@ -221,23 +237,31 @@ The complete augmented dictionary is represented as an `AugmentedDictionary` Pyd
 
 ```python
 class AugmentedDictionary(StrictBaseModel):
-    dataset_id: Optional[str]                # source dataset identifier
-    themes: List[Theme]                      # one per cluster
-    variable_assignments: List[ThemeAssignment]  # one per input variable
-    metadata: Optional[Dict[str, Any]]       # run config, model, timestamp
+    dataset_id: Optional[str]
+    variable_groups: List[VariableGroup]              # one per cluster
+    variable_assignments: List[VariableGroupAssignment]  # curated variables only
+    metadata: Optional[Dict[str, Any]]
 ```
 
 Where:
 
 ```python
-class Theme(StrictBaseModel):
-    theme_name: str
-    description: str
-    example_variables: List[str]   # 1–5 representative variable names
+class VariableGroup(StrictBaseModel):
+    vgid: str
+    variables: str           # space-separated curated variable names
+    variable_groups: str = ""
+    group_type: str = "subject"
+    label: str
+    universe: str = ""
+    notes: str = ""
+    txt: str
+    definition: str
+    cluster_id: int
 
-class ThemeAssignment(StrictBaseModel):
+class VariableGroupAssignment(StrictBaseModel):
     variable_name: str
-    theme_name: str
+    vgid: str
+    label: str
     cluster_id: int
 ```
 
@@ -249,12 +273,12 @@ The `metadata` field records the model name, embedding model, number of variable
 # JSON file
 augmentor.export("augmented_dictionary.json")
 
-# pandas DataFrame (variable_name, theme_name, cluster_id)
+# pandas DataFrame (variable_name, vgid, label, cluster_id)
 df = augmentor.to_dataframe()
 
 # Direct Pydantic model access
 result = augmentor.result
-themes = {t.theme_name: t.description for t in result.themes}
+groups = {g.vgid: g.txt for g in result.variable_groups}
 ```
 
 ---

--- a/src/ai4data/metadata/augmentation/__init__.py
+++ b/src/ai4data/metadata/augmentation/__init__.py
@@ -24,7 +24,7 @@ The pipeline: Load → Embed → Cluster → Generate Variable Groups → Export
 See :class:`DataDictionaryAugmentor` for the full API.
 """
 
-from . import adapters, clustering, embeddings, prompts, schemas
+from . import adapters, clustering, embeddings, prompts, qa, schemas
 from .adapters import (
     ConfigurableDictionaryAdapter,
     NADACatalogAdapter,
@@ -37,6 +37,7 @@ from .schemas import (
     VariableGroup,
     VariableGroupAssignment,
     VariableGroupCurationResult,
+    VariableGroupQAResult,
     make_vgid,
 )
 
@@ -54,11 +55,13 @@ __all__ = [
     "VariableGroup",
     "VariableGroupAssignment",
     "VariableGroupCurationResult",
+    "VariableGroupQAResult",
     "make_vgid",
     # Submodules
     "adapters",
     "clustering",
     "embeddings",
     "prompts",
+    "qa",
     "schemas",
 ]

--- a/src/ai4data/metadata/augmentation/__init__.py
+++ b/src/ai4data/metadata/augmentation/__init__.py
@@ -1,7 +1,7 @@
 """ai4data.metadata.augmentation — LLM-powered data dictionary augmentation.
 
-Automatically generates thematic structure for microdata or administrative
-data dictionary variables using semantic clustering and LLM-elicited themes.
+Automatically generates DDI-style variable groups for microdata or administrative
+data dictionary variables using semantic clustering and LLM-elicited curation.
 
 Install
 -------
@@ -19,7 +19,7 @@ Quick Start
     result = augmentor.augment("variables.csv")
     augmentor.export("augmented.json")
 
-The pipeline: Load → Embed → Cluster → Generate Themes → Export.
+The pipeline: Load → Embed → Cluster → Generate Variable Groups → Export.
 
 See :class:`DataDictionaryAugmentor` for the full API.
 """
@@ -34,9 +34,10 @@ from .augmentor import DEFAULT_MODEL, DataDictionaryAugmentor
 from .schemas import (
     AugmentedDictionary,
     DictionaryVariable,
-    Theme,
-    ThemeAssignment,
-    ThemeGenerationResult,
+    VariableGroup,
+    VariableGroupAssignment,
+    VariableGroupCurationResult,
+    make_vgid,
 )
 
 __all__ = [
@@ -50,9 +51,10 @@ __all__ = [
     # Schemas
     "AugmentedDictionary",
     "DictionaryVariable",
-    "Theme",
-    "ThemeAssignment",
-    "ThemeGenerationResult",
+    "VariableGroup",
+    "VariableGroupAssignment",
+    "VariableGroupCurationResult",
+    "make_vgid",
     # Submodules
     "adapters",
     "clustering",

--- a/src/ai4data/metadata/augmentation/augmentor.py
+++ b/src/ai4data/metadata/augmentation/augmentor.py
@@ -8,7 +8,7 @@
 5. Export: write the augmented dictionary to disk or return as a DataFrame
 
 The LLM backend is provider-agnostic via ``litellm``: set ``model`` to any
-litellm-supported model string (e.g., ``"claude-haiku-4-5-20251001"``,
+litellm-supported model string (e.g., ``"claude-sonnet-4-6"``,
 ``"gpt-4o-mini"``, ``"gemini/gemini-2.0-flash"``).
 
 Install requirements: ``uv pip install ai4data[metadata]``
@@ -43,17 +43,23 @@ from .prompts import (
     get_variable_group_response_format,
     render_user_prompt,
 )
+from .qa import (
+    QA_SYSTEM_PROMPT,
+    get_qa_response_format,
+    render_qa_user_prompt,
+)
 from .schemas import (
     AugmentedDictionary,
     DictionaryVariable,
     VariableGroup,
     VariableGroupAssignment,
     VariableGroupCurationResult,
+    VariableGroupQAResult,
 )
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+DEFAULT_MODEL = "claude-sonnet-4-6"
 
 
 class DataDictionaryAugmentor:
@@ -65,8 +71,12 @@ class DataDictionaryAugmentor:
     Parameters
     ----------
     model : str
-        LiteLLM model string. Defaults to ``"claude-haiku-4-5-20251001"``.
+        LiteLLM model string for curation. Defaults to ``"claude-sonnet-4-6"``.
         Other examples: ``"gpt-4o-mini"``, ``"gemini/gemini-2.0-flash"``.
+    qa_model : str, optional
+        LiteLLM model string for self-consistency QA. Defaults to ``model``.
+    enable_qa : bool
+        When True, run a QA agent after each successful curation call.
     embedding_model : str
         SentenceTransformer model name. Defaults to ``"BAAI/bge-small-en-v1.5"``.
     n_clusters : int, optional
@@ -105,6 +115,8 @@ class DataDictionaryAugmentor:
     def __init__(
         self,
         model: str = DEFAULT_MODEL,
+        qa_model: Optional[str] = None,
+        enable_qa: bool = True,
         embedding_model: str = DEFAULT_EMBEDDING_MODEL,
         n_clusters: Optional[int] = None,
         max_cluster_tokens: int = DEFAULT_MAX_CLUSTER_TOKENS,
@@ -113,6 +125,8 @@ class DataDictionaryAugmentor:
         device: Optional[str] = None,
     ):
         self.model = model
+        self.qa_model = qa_model or model
+        self.enable_qa = enable_qa
         self.n_clusters = n_clusters
         self.max_cluster_tokens = max_cluster_tokens
         self.temperature = temperature
@@ -284,9 +298,10 @@ class DataDictionaryAugmentor:
     def generate_variable_groups(self) -> AugmentedDictionary:
         """Call the LLM for each cluster and assemble the augmented dictionary.
 
-        Makes one LLM call per cluster. Failures in individual clusters are
-        logged and handled with a fallback ``VariableGroup`` so that partial
-        results are always returned.
+        Makes one curation LLM call per cluster, optionally followed by a
+        self-consistency QA call. Failures in individual clusters are logged
+        and handled with a fallback ``VariableGroup`` so that partial results
+        are always returned.
 
         Returns
         -------
@@ -297,14 +312,41 @@ class DataDictionaryAugmentor:
 
         variable_groups: List[VariableGroup] = []
         variable_assignments: List[VariableGroupAssignment] = []
+        n_qa_passed = 0
+        n_qa_failed = 0
+        n_qa_skipped = 0
 
         for cluster_id, vars_ in self._cluster_map.items():
             curation = self._call_llm_for_cluster(cluster_id, vars_)
 
             if curation is not None:
-                group = VariableGroup.from_curation(
-                    curation, cluster_id=cluster_id
+                qa_result = (
+                    self._call_qa_for_curation(cluster_id, vars_, curation)
+                    if self.enable_qa
+                    else None
                 )
+                if qa_result is not None:
+                    if qa_result.is_self_consistent:
+                        n_qa_passed += 1
+                    else:
+                        n_qa_failed += 1
+                    group = VariableGroup.from_curation(
+                        curation,
+                        cluster_id=cluster_id,
+                        qa=qa_result,
+                    )
+                elif self.enable_qa:
+                    n_qa_skipped += 1
+                    group = VariableGroup.from_curation(
+                        curation,
+                        cluster_id=cluster_id,
+                        qa_error="QA call failed",
+                    )
+                else:
+                    group = VariableGroup.from_curation(
+                        curation,
+                        cluster_id=cluster_id,
+                    )
                 assigned_names = curation.variables
             else:
                 all_names = [v.variable_name for v in vars_]
@@ -325,17 +367,29 @@ class DataDictionaryAugmentor:
                     )
                 )
 
+        metadata: Dict[str, Any] = {
+            "model": self.model,
+            "embedding_model": self._encoder.model_name,
+            "n_variables": len(self._variables),
+            "n_clusters": len(self._cluster_map),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "enable_qa": self.enable_qa,
+        }
+        if self.enable_qa:
+            metadata.update(
+                {
+                    "qa_model": self.qa_model,
+                    "n_qa_passed": n_qa_passed,
+                    "n_qa_failed": n_qa_failed,
+                    "n_qa_skipped": n_qa_skipped,
+                }
+            )
+
         self._result = AugmentedDictionary(
             dataset_id=getattr(self, "_dataset_id", None),
             variable_groups=variable_groups,
             variable_assignments=variable_assignments,
-            metadata={
-                "model": self.model,
-                "embedding_model": self._encoder.model_name,
-                "n_variables": len(self._variables),
-                "n_clusters": len(self._cluster_map),
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-            },
+            metadata=metadata,
         )
         return self._result
 
@@ -444,27 +498,18 @@ class DataDictionaryAugmentor:
         ]
         return pd.DataFrame(rows)
 
-    # ----- Internal LLM call ----- #
+    # ----- Internal LLM calls ----- #
 
-    def _call_llm_for_cluster(
+    def _litellm_json_completion(
         self,
+        *,
+        model: str,
+        messages: List[Dict[str, str]],
+        response_format: Dict,
         cluster_id: int,
-        variables: List[DictionaryVariable],
-    ) -> Optional[VariableGroupCurationResult]:
-        """Make one litellm completion call for a single cluster.
-
-        Parameters
-        ----------
-        cluster_id : int
-            Cluster identifier (used for logging).
-        variables : list of DictionaryVariable
-            Variables in this cluster.
-
-        Returns
-        -------
-        VariableGroupCurationResult or None
-            Parsed and validated result, or None if the call failed.
-        """
+        call_label: str,
+    ) -> Optional[str]:
+        """Run a litellm completion and return raw JSON content, or None."""
         try:
             import litellm
         except ImportError as exc:
@@ -473,52 +518,110 @@ class DataDictionaryAugmentor:
                 "Install with: uv pip install ai4data[metadata]"
             ) from exc
 
-        candidate_names = {v.variable_name for v in variables}
-        user_prompt = render_user_prompt(variables)
-        messages = [
-            {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": user_prompt},
-        ]
-
-        # Try structured output first; fall back to json_object mode
-        response_format = get_variable_group_response_format()
         try:
             response = litellm.completion(
-                model=self.model,
+                model=model,
                 messages=messages,
                 response_format=response_format,
                 temperature=self.temperature,
             )
         except Exception:
-            # Some providers don't support strict JSON schema; retry with json_object
             try:
                 response = litellm.completion(
-                    model=self.model,
+                    model=model,
                     messages=messages,
                     response_format=get_json_object_format(),
                     temperature=self.temperature,
                 )
             except Exception as exc2:
                 logger.warning(
-                    "LLM call failed for cluster %d (%d variables): %s",
+                    "%s call failed for cluster %d: %s",
+                    call_label,
                     cluster_id,
-                    len(variables),
                     exc2,
                 )
                 return None
 
         try:
-            content = response.choices[0].message.content
+            return response.choices[0].message.content
+        except Exception as exc:
+            logger.warning(
+                "%s response missing content for cluster %d: %s",
+                call_label,
+                cluster_id,
+                exc,
+            )
+            return None
+
+    def _call_llm_for_cluster(
+        self,
+        cluster_id: int,
+        variables: List[DictionaryVariable],
+    ) -> Optional[VariableGroupCurationResult]:
+        """Make one litellm completion call for a single cluster."""
+        candidate_names = {v.variable_name for v in variables}
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": render_user_prompt(variables)},
+        ]
+
+        content = self._litellm_json_completion(
+            model=self.model,
+            messages=messages,
+            response_format=get_variable_group_response_format(),
+            cluster_id=cluster_id,
+            call_label="Curation",
+        )
+        if content is None:
+            return None
+
+        try:
             return VariableGroupCurationResult.from_llm_response(
                 content,
                 candidate_names=candidate_names,
             )
         except Exception as exc:
             logger.warning(
-                "Failed to parse LLM response for cluster %d: %s\nContent: %s",
+                "Failed to parse curation response for cluster %d: %s\nContent: %s",
                 cluster_id,
                 exc,
-                response.choices[0].message.content[:300] if response else "",
+                content[:300],
+            )
+            return None
+
+    def _call_qa_for_curation(
+        self,
+        cluster_id: int,
+        variables: List[DictionaryVariable],
+        curation: VariableGroupCurationResult,
+    ) -> Optional[VariableGroupQAResult]:
+        """Run the self-consistency QA agent on a curation result."""
+        messages = [
+            {"role": "system", "content": QA_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": render_qa_user_prompt(variables, curation),
+            },
+        ]
+
+        content = self._litellm_json_completion(
+            model=self.qa_model,
+            messages=messages,
+            response_format=get_qa_response_format(),
+            cluster_id=cluster_id,
+            call_label="QA",
+        )
+        if content is None:
+            return None
+
+        try:
+            return VariableGroupQAResult.model_validate_json(content)
+        except Exception as exc:
+            logger.warning(
+                "Failed to parse QA response for cluster %d: %s\nContent: %s",
+                cluster_id,
+                exc,
+                content[:300],
             )
             return None
 

--- a/src/ai4data/metadata/augmentation/augmentor.py
+++ b/src/ai4data/metadata/augmentation/augmentor.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 
 from .adapters import (
     ConfigurableDictionaryAdapter,
@@ -62,6 +64,16 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = "claude-sonnet-4-6"
 
 
+@dataclass
+class _ClusterProcessResult:
+    cluster_id: int
+    group: VariableGroup
+    assignments: List[VariableGroupAssignment]
+    n_qa_passed: int = 0
+    n_qa_failed: int = 0
+    n_qa_skipped: int = 0
+
+
 class DataDictionaryAugmentor:
     """LLM-powered data dictionary augmentation.
 
@@ -87,6 +99,10 @@ class DataDictionaryAugmentor:
         LLM temperature. Use 0.0 for deterministic outputs.
     random_state : int
         Random seed for clustering and silhouette estimation.
+    max_concurrency : int
+        Maximum number of clusters to process in parallel during LLM
+        generation. Defaults to ``1`` (sequential). Increase to reduce
+        wall-clock time; watch provider rate limits.
     device : str, optional
         Embedding inference device (``"cuda"``, ``"mps"``, ``"cpu"``).
         Auto-detected if not specified.
@@ -122,6 +138,7 @@ class DataDictionaryAugmentor:
         max_cluster_tokens: int = DEFAULT_MAX_CLUSTER_TOKENS,
         temperature: float = 0.0,
         random_state: int = 42,
+        max_concurrency: int = 1,
         device: Optional[str] = None,
     ):
         self.model = model
@@ -131,6 +148,7 @@ class DataDictionaryAugmentor:
         self.max_cluster_tokens = max_cluster_tokens
         self.temperature = temperature
         self.random_state = random_state
+        self.max_concurrency = max_concurrency
 
         self._encoder = EmbeddingEncoder(embedding_model, device=device)
         self._variables: Optional[List[DictionaryVariable]] = None
@@ -299,6 +317,7 @@ class DataDictionaryAugmentor:
         self,
         *,
         show_progress_bar: bool = False,
+        max_concurrency: Optional[int] = None,
     ) -> AugmentedDictionary:
         """Call the LLM for each cluster and assemble the augmented dictionary.
 
@@ -311,6 +330,10 @@ class DataDictionaryAugmentor:
         ----------
         show_progress_bar : bool
             Display a tqdm progress bar during LLM calls per cluster.
+        max_concurrency : int, optional
+            Override the instance-level ``max_concurrency`` for this run.
+            When greater than 1, clusters are processed in parallel via a
+            thread pool.
 
         Returns
         -------
@@ -319,77 +342,24 @@ class DataDictionaryAugmentor:
         """
         self._require_clustered()
 
-        variable_groups: List[VariableGroup] = []
+        concurrency = (
+            max_concurrency if max_concurrency is not None else self.max_concurrency
+        )
+        items = list(self._cluster_map.items())
+        results = self._process_clusters(
+            items,
+            concurrency=concurrency,
+            show_progress_bar=show_progress_bar,
+        )
+
+        variable_groups = [r.group for r in results]
         variable_assignments: List[VariableGroupAssignment] = []
-        n_qa_passed = 0
-        n_qa_failed = 0
-        n_qa_skipped = 0
+        for result in results:
+            variable_assignments.extend(result.assignments)
 
-        clusters = self._cluster_map.items()
-        pbar = None
-        if show_progress_bar:
-            from tqdm import tqdm
-
-            pbar = tqdm(
-                clusters,
-                total=len(self._cluster_map),
-                desc="Variable groups",
-            )
-            clusters = pbar
-
-        for cluster_id, vars_ in clusters:
-            curation = self._call_llm_for_cluster(cluster_id, vars_)
-
-            if curation is not None:
-                qa_result = (
-                    self._call_qa_for_curation(cluster_id, vars_, curation)
-                    if self.enable_qa
-                    else None
-                )
-                if qa_result is not None:
-                    if qa_result.is_self_consistent:
-                        n_qa_passed += 1
-                    else:
-                        n_qa_failed += 1
-                    group = VariableGroup.from_curation(
-                        curation,
-                        cluster_id=cluster_id,
-                        qa=qa_result,
-                    )
-                elif self.enable_qa:
-                    n_qa_skipped += 1
-                    group = VariableGroup.from_curation(
-                        curation,
-                        cluster_id=cluster_id,
-                        qa_error="QA call failed",
-                    )
-                else:
-                    group = VariableGroup.from_curation(
-                        curation,
-                        cluster_id=cluster_id,
-                    )
-                assigned_names = curation.variables
-            else:
-                all_names = [v.variable_name for v in vars_]
-                group = VariableGroup.uncategorized_fallback(
-                    cluster_id=cluster_id,
-                    variable_names=all_names,
-                )
-                assigned_names = all_names
-
-            variable_groups.append(group)
-            for name in assigned_names:
-                variable_assignments.append(
-                    VariableGroupAssignment(
-                        variable_name=name,
-                        vgid=group.vgid,
-                        label=group.label,
-                        cluster_id=cluster_id,
-                    )
-                )
-
-            if pbar is not None:
-                pbar.set_postfix(cluster=cluster_id, label=group.label[:30])
+        n_qa_passed = sum(r.n_qa_passed for r in results)
+        n_qa_failed = sum(r.n_qa_failed for r in results)
+        n_qa_skipped = sum(r.n_qa_skipped for r in results)
 
         metadata: Dict[str, Any] = {
             "model": self.model,
@@ -398,6 +368,7 @@ class DataDictionaryAugmentor:
             "n_clusters": len(self._cluster_map),
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "enable_qa": self.enable_qa,
+            "max_concurrency": concurrency,
         }
         if self.enable_qa:
             metadata.update(
@@ -428,6 +399,7 @@ class DataDictionaryAugmentor:
         n_clusters: Optional[int] = None,
         dataset_id: Optional[str] = None,
         show_progress_bar: bool = False,
+        max_concurrency: Optional[int] = None,
     ) -> AugmentedDictionary:
         """Load → embed → cluster → generate variable groups in one call.
 
@@ -445,6 +417,9 @@ class DataDictionaryAugmentor:
             Dataset identifier for output metadata.
         show_progress_bar : bool
             Show tqdm progress bars during embedding and variable group generation.
+        max_concurrency : int, optional
+            Override parallel LLM concurrency for variable group generation
+            (see ``generate_variable_groups()``).
 
         Returns
         -------
@@ -459,7 +434,10 @@ class DataDictionaryAugmentor:
             )
             .embed(show_progress_bar=show_progress_bar)
             .cluster(n_clusters=n_clusters)
-            .generate_variable_groups(show_progress_bar=show_progress_bar)
+            .generate_variable_groups(
+                show_progress_bar=show_progress_bar,
+                max_concurrency=max_concurrency,
+            )
         )
 
     # ----- Export ----- #
@@ -521,6 +499,136 @@ class DataDictionaryAugmentor:
             for a in self._result.variable_assignments
         ]
         return pd.DataFrame(rows)
+
+    # ----- Internal cluster processing ----- #
+
+    def _process_cluster(
+        self,
+        cluster_id: int,
+        vars_: List[DictionaryVariable],
+    ) -> _ClusterProcessResult:
+        """Run curation (and optional QA) for a single cluster."""
+        n_qa_passed = 0
+        n_qa_failed = 0
+        n_qa_skipped = 0
+
+        curation = self._call_llm_for_cluster(cluster_id, vars_)
+
+        if curation is not None:
+            qa_result = (
+                self._call_qa_for_curation(cluster_id, vars_, curation)
+                if self.enable_qa
+                else None
+            )
+            if qa_result is not None:
+                if qa_result.is_self_consistent:
+                    n_qa_passed = 1
+                else:
+                    n_qa_failed = 1
+                group = VariableGroup.from_curation(
+                    curation,
+                    cluster_id=cluster_id,
+                    qa=qa_result,
+                )
+            elif self.enable_qa:
+                n_qa_skipped = 1
+                group = VariableGroup.from_curation(
+                    curation,
+                    cluster_id=cluster_id,
+                    qa_error="QA call failed",
+                )
+            else:
+                group = VariableGroup.from_curation(
+                    curation,
+                    cluster_id=cluster_id,
+                )
+            assigned_names = curation.variables
+        else:
+            all_names = [v.variable_name for v in vars_]
+            group = VariableGroup.uncategorized_fallback(
+                cluster_id=cluster_id,
+                variable_names=all_names,
+            )
+            assigned_names = all_names
+
+        assignments = [
+            VariableGroupAssignment(
+                variable_name=name,
+                vgid=group.vgid,
+                label=group.label,
+                cluster_id=cluster_id,
+            )
+            for name in assigned_names
+        ]
+
+        return _ClusterProcessResult(
+            cluster_id=cluster_id,
+            group=group,
+            assignments=assignments,
+            n_qa_passed=n_qa_passed,
+            n_qa_failed=n_qa_failed,
+            n_qa_skipped=n_qa_skipped,
+        )
+
+    def _process_clusters(
+        self,
+        items: List[tuple[int, List[DictionaryVariable]]],
+        *,
+        concurrency: int,
+        show_progress_bar: bool,
+    ) -> List[_ClusterProcessResult]:
+        """Process all clusters sequentially or in parallel."""
+        if concurrency <= 1:
+            if show_progress_bar:
+                from tqdm import tqdm
+
+                results: List[_ClusterProcessResult] = []
+                with tqdm(
+                    items,
+                    total=len(items),
+                    desc="Variable groups",
+                ) as pbar:
+                    for cluster_id, vars_ in pbar:
+                        result = self._process_cluster(cluster_id, vars_)
+                        results.append(result)
+                        pbar.set_postfix(
+                            cluster=result.cluster_id,
+                            label=result.group.label[:30],
+                        )
+                return results
+
+            return [
+                self._process_cluster(cluster_id, vars_)
+                for cluster_id, vars_ in items
+            ]
+
+        if show_progress_bar:
+            from tqdm import tqdm
+
+            results: List[Optional[_ClusterProcessResult]] = [None] * len(items)
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                future_to_index = {
+                    executor.submit(self._process_cluster, cid, vars_): i
+                    for i, (cid, vars_) in enumerate(items)
+                }
+                with tqdm(total=len(items), desc="Variable groups") as pbar:
+                    for future in as_completed(future_to_index):
+                        result = future.result()
+                        results[future_to_index[future]] = result
+                        pbar.set_postfix(
+                            cluster=result.cluster_id,
+                            label=result.group.label[:30],
+                        )
+                        pbar.update(1)
+            return cast(List[_ClusterProcessResult], results)
+
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            return list(
+                executor.map(
+                    lambda kv: self._process_cluster(kv[0], kv[1]),
+                    items,
+                )
+            )
 
     # ----- Internal LLM calls ----- #
 

--- a/src/ai4data/metadata/augmentation/augmentor.py
+++ b/src/ai4data/metadata/augmentation/augmentor.py
@@ -295,13 +295,22 @@ class DataDictionaryAugmentor:
 
     # ----- Step 4: Generate variable groups ----- #
 
-    def generate_variable_groups(self) -> AugmentedDictionary:
+    def generate_variable_groups(
+        self,
+        *,
+        show_progress_bar: bool = False,
+    ) -> AugmentedDictionary:
         """Call the LLM for each cluster and assemble the augmented dictionary.
 
         Makes one curation LLM call per cluster, optionally followed by a
         self-consistency QA call. Failures in individual clusters are logged
         and handled with a fallback ``VariableGroup`` so that partial results
         are always returned.
+
+        Parameters
+        ----------
+        show_progress_bar : bool
+            Display a tqdm progress bar during LLM calls per cluster.
 
         Returns
         -------
@@ -316,7 +325,19 @@ class DataDictionaryAugmentor:
         n_qa_failed = 0
         n_qa_skipped = 0
 
-        for cluster_id, vars_ in self._cluster_map.items():
+        clusters = self._cluster_map.items()
+        pbar = None
+        if show_progress_bar:
+            from tqdm import tqdm
+
+            pbar = tqdm(
+                clusters,
+                total=len(self._cluster_map),
+                desc="Variable groups",
+            )
+            clusters = pbar
+
+        for cluster_id, vars_ in clusters:
             curation = self._call_llm_for_cluster(cluster_id, vars_)
 
             if curation is not None:
@@ -366,6 +387,9 @@ class DataDictionaryAugmentor:
                         cluster_id=cluster_id,
                     )
                 )
+
+            if pbar is not None:
+                pbar.set_postfix(cluster=cluster_id, label=group.label[:30])
 
         metadata: Dict[str, Any] = {
             "model": self.model,
@@ -420,7 +444,7 @@ class DataDictionaryAugmentor:
         dataset_id : str, optional
             Dataset identifier for output metadata.
         show_progress_bar : bool
-            Show embedding progress bar.
+            Show tqdm progress bars during embedding and variable group generation.
 
         Returns
         -------
@@ -435,7 +459,7 @@ class DataDictionaryAugmentor:
             )
             .embed(show_progress_bar=show_progress_bar)
             .cluster(n_clusters=n_clusters)
-            .generate_variable_groups()
+            .generate_variable_groups(show_progress_bar=show_progress_bar)
         )
 
     # ----- Export ----- #

--- a/src/ai4data/metadata/augmentation/augmentor.py
+++ b/src/ai4data/metadata/augmentation/augmentor.py
@@ -4,7 +4,7 @@
 1. Load: ingest variables from CSV, JSON, dict, or NADA catalog
 2. Embed: encode variable labels/descriptions with sentence-transformers
 3. Cluster: group semantically similar variables
-4. Generate: call an LLM for each cluster to produce a theme name + description
+4. Generate: call an LLM for each cluster to curate a DDI variable group
 5. Export: write the augmented dictionary to disk or return as a DataFrame
 
 The LLM backend is provider-agnostic via ``litellm``: set ``model`` to any
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 import logging
-import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -41,15 +40,15 @@ from .embeddings import DEFAULT_EMBEDDING_MODEL, EmbeddingEncoder
 from .prompts import (
     SYSTEM_PROMPT,
     get_json_object_format,
-    get_theme_response_format,
+    get_variable_group_response_format,
     render_user_prompt,
 )
 from .schemas import (
     AugmentedDictionary,
     DictionaryVariable,
-    Theme,
-    ThemeAssignment,
-    ThemeGenerationResult,
+    VariableGroup,
+    VariableGroupAssignment,
+    VariableGroupCurationResult,
 )
 
 logger = logging.getLogger(__name__)
@@ -60,8 +59,8 @@ DEFAULT_MODEL = "claude-haiku-4-5-20251001"
 class DataDictionaryAugmentor:
     """LLM-powered data dictionary augmentation.
 
-    Generates thematic structure for microdata or administrative data dictionary
-    variables using semantic clustering and LLM-elicited theme names.
+    Generates DDI-style variable groups for microdata or administrative data
+    dictionary variables using semantic clustering and LLM-elicited curation.
 
     Parameters
     ----------
@@ -99,7 +98,7 @@ class DataDictionaryAugmentor:
     ...     .load("dictionary.csv", adapter=adapter)
     ...     .embed(show_progress_bar=True)
     ...     .cluster(n_clusters=10)
-    ...     .generate_themes()
+    ...     .generate_variable_groups()
     ... )
     """
 
@@ -280,61 +279,55 @@ class DataDictionaryAugmentor:
         self._result = None
         return self
 
-    # ----- Step 4: Generate themes ----- #
+    # ----- Step 4: Generate variable groups ----- #
 
-    def generate_themes(self) -> AugmentedDictionary:
+    def generate_variable_groups(self) -> AugmentedDictionary:
         """Call the LLM for each cluster and assemble the augmented dictionary.
 
         Makes one LLM call per cluster. Failures in individual clusters are
-        logged and skipped (returning a ``Theme`` with name "Uncategorized" for
-        affected variables) so that partial results are always returned.
+        logged and handled with a fallback ``VariableGroup`` so that partial
+        results are always returned.
 
         Returns
         -------
         AugmentedDictionary
-            The complete augmented dictionary with all themes and assignments.
+            The complete augmented dictionary with variable groups and assignments.
         """
         self._require_clustered()
 
-        themes: List[Theme] = []
-        variable_assignments: List[ThemeAssignment] = []
-        cluster_to_theme: Dict[int, str] = {}
+        variable_groups: List[VariableGroup] = []
+        variable_assignments: List[VariableGroupAssignment] = []
 
         for cluster_id, vars_ in self._cluster_map.items():
-            result = self._call_llm_for_cluster(cluster_id, vars_)
-            if result is not None:
-                theme = Theme(
-                    theme_name=result.theme_name,
-                    description=result.description,
-                    example_variables=result.example_variables[:5],
+            curation = self._call_llm_for_cluster(cluster_id, vars_)
+
+            if curation is not None:
+                group = VariableGroup.from_curation(
+                    curation, cluster_id=cluster_id
                 )
-                theme_name = result.theme_name
+                assigned_names = curation.variables
             else:
-                # Graceful fallback for failed LLM calls
-                theme = Theme(
-                    theme_name="Uncategorized",
-                    description="Theme generation failed for this cluster.",
-                    example_variables=[vars_[0].variable_name] if vars_ else [],
+                all_names = [v.variable_name for v in vars_]
+                group = VariableGroup.uncategorized_fallback(
+                    cluster_id=cluster_id,
+                    variable_names=all_names,
                 )
-                theme_name = "Uncategorized"
+                assigned_names = all_names
 
-            themes.append(theme)
-            cluster_to_theme[cluster_id] = theme_name
-
-        # Build per-variable assignments
-        for idx, var in enumerate(self._variables):
-            cid = int(self._cluster_labels[idx])
-            variable_assignments.append(
-                ThemeAssignment(
-                    variable_name=var.variable_name,
-                    theme_name=cluster_to_theme.get(cid, "Uncategorized"),
-                    cluster_id=cid,
+            variable_groups.append(group)
+            for name in assigned_names:
+                variable_assignments.append(
+                    VariableGroupAssignment(
+                        variable_name=name,
+                        vgid=group.vgid,
+                        label=group.label,
+                        cluster_id=cluster_id,
+                    )
                 )
-            )
 
         self._result = AugmentedDictionary(
             dataset_id=getattr(self, "_dataset_id", None),
-            themes=themes,
+            variable_groups=variable_groups,
             variable_assignments=variable_assignments,
             metadata={
                 "model": self.model,
@@ -358,7 +351,7 @@ class DataDictionaryAugmentor:
         dataset_id: Optional[str] = None,
         show_progress_bar: bool = False,
     ) -> AugmentedDictionary:
-        """Load → embed → cluster → generate themes in one call.
+        """Load → embed → cluster → generate variable groups in one call.
 
         Parameters
         ----------
@@ -388,7 +381,7 @@ class DataDictionaryAugmentor:
             )
             .embed(show_progress_bar=show_progress_bar)
             .cluster(n_clusters=n_clusters)
-            .generate_themes()
+            .generate_variable_groups()
         )
 
     # ----- Export ----- #
@@ -432,8 +425,8 @@ class DataDictionaryAugmentor:
         Returns
         -------
         pandas.DataFrame
-            One row per variable with columns: ``variable_name``,
-            ``theme_name``, ``cluster_id``.
+            One row per curated variable with columns: ``variable_name``,
+            ``vgid``, ``label``, ``cluster_id``.
         """
         self._require_result()
         try:
@@ -443,7 +436,8 @@ class DataDictionaryAugmentor:
         rows = [
             {
                 "variable_name": a.variable_name,
-                "theme_name": a.theme_name,
+                "vgid": a.vgid,
+                "label": a.label,
                 "cluster_id": a.cluster_id,
             }
             for a in self._result.variable_assignments
@@ -456,7 +450,7 @@ class DataDictionaryAugmentor:
         self,
         cluster_id: int,
         variables: List[DictionaryVariable],
-    ) -> Optional[ThemeGenerationResult]:
+    ) -> Optional[VariableGroupCurationResult]:
         """Make one litellm completion call for a single cluster.
 
         Parameters
@@ -468,8 +462,8 @@ class DataDictionaryAugmentor:
 
         Returns
         -------
-        ThemeGenerationResult or None
-            Parsed result, or None if the call failed.
+        VariableGroupCurationResult or None
+            Parsed and validated result, or None if the call failed.
         """
         try:
             import litellm
@@ -479,6 +473,7 @@ class DataDictionaryAugmentor:
                 "Install with: uv pip install ai4data[metadata]"
             ) from exc
 
+        candidate_names = {v.variable_name for v in variables}
         user_prompt = render_user_prompt(variables)
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
@@ -486,7 +481,7 @@ class DataDictionaryAugmentor:
         ]
 
         # Try structured output first; fall back to json_object mode
-        response_format = get_theme_response_format()
+        response_format = get_variable_group_response_format()
         try:
             response = litellm.completion(
                 model=self.model,
@@ -514,7 +509,10 @@ class DataDictionaryAugmentor:
 
         try:
             content = response.choices[0].message.content
-            return ThemeGenerationResult.model_validate_json(content)
+            return VariableGroupCurationResult.from_llm_response(
+                content,
+                candidate_names=candidate_names,
+            )
         except Exception as exc:
             logger.warning(
                 "Failed to parse LLM response for cluster %d: %s\nContent: %s",
@@ -543,13 +541,15 @@ class DataDictionaryAugmentor:
         self._require_embedded()
         if self._cluster_labels is None or self._cluster_map is None:
             raise RuntimeError(
-                "Clustering not done. Call .cluster() before .generate_themes()."
+                "Clustering not done. Call .cluster() before "
+                ".generate_variable_groups()."
             )
 
     def _require_result(self) -> None:
         if self._result is None:
             raise RuntimeError(
-                "No result available. Call .generate_themes() or .augment() first."
+                "No result available. Call .generate_variable_groups() or "
+                ".augment() first."
             )
 
     # ----- Properties ----- #

--- a/src/ai4data/metadata/augmentation/augmentor.py
+++ b/src/ai4data/metadata/augmentation/augmentor.py
@@ -35,7 +35,7 @@ from .clustering import (
     DEFAULT_SVD_THRESHOLD,
     build_cluster_map,
     cluster_variables,
-    merge_clusters_for_token_budget,
+    split_clusters_for_token_budget,
     reduce_dimensions,
 )
 from .embeddings import DEFAULT_EMBEDDING_MODEL, EmbeddingEncoder
@@ -301,7 +301,7 @@ class DataDictionaryAugmentor:
             random_state=self.random_state,
         )
         # Enforce token budget per cluster
-        labels = merge_clusters_for_token_budget(
+        labels = split_clusters_for_token_budget(
             labels,
             self._variables,
             max_tokens_per_cluster=self.max_cluster_tokens,

--- a/src/ai4data/metadata/augmentation/clustering.py
+++ b/src/ai4data/metadata/augmentation/clustering.py
@@ -4,7 +4,7 @@ Pipeline:
 1. Optionally reduce dimensionality with TruncatedSVD (for large dictionaries).
 2. Estimate optimal number of clusters via silhouette score (or use heuristic).
 3. Run AgglomerativeClustering with Ward linkage.
-4. Post-hoc token-budget merge: combine clusters that would exceed the LLM
+4. Post-hoc token-budget split: subdivide clusters that would exceed the LLM
    context limit when rendered as a variable list.
 
 All sklearn/numpy imports are lazy to avoid import-time overhead.
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 DEFAULT_SVD_COMPONENTS = 64
 DEFAULT_SVD_THRESHOLD = 150        # apply SVD only when N > this
 DEFAULT_N_CLUSTERS_RANGE = (3, 30)
-DEFAULT_MAX_CLUSTER_TOKENS = 450   # max tokens per cluster for LLM prompt
+DEFAULT_MAX_CLUSTER_TOKENS = 2048  # max tokens per cluster for LLM prompt
 DEFAULT_APPROX_TOKENS_PER_LABEL = 10  # conservative estimate per "name: label" line
 
 
@@ -244,12 +244,13 @@ def merge_clusters_for_token_budget(
     max_tokens_per_cluster: int = DEFAULT_MAX_CLUSTER_TOKENS,
     approx_tokens_per_label: int = DEFAULT_APPROX_TOKENS_PER_LABEL,
 ) -> "np.ndarray":
-    """Merge clusters that exceed the token budget into adjacent smaller clusters.
+    """Split clusters that exceed the token budget into smaller clusters.
 
     This post-hoc step ensures that each LLM call receives a variable list that
-    fits within the context window. Clusters are merged greedily: the largest
-    cluster is split by merging it with the cluster whose combined token count
-    still fits the budget.
+    fits within the context window. When a cluster is oversized, the minimum
+    number of trailing variables are moved into a new cluster until the
+    remainder fits the budget. The process repeats until all clusters comply,
+    or a single variable alone exceeds the limit (left unchanged).
 
     Parameters
     ----------
@@ -265,39 +266,48 @@ def merge_clusters_for_token_budget(
     Returns
     -------
     numpy.ndarray
-        Updated label array (same length, possibly fewer unique values).
+        Updated label array (same length, possibly more unique cluster IDs).
     """
-    import numpy as np
-
     labels = cluster_labels.copy()
     cluster_map = build_cluster_map(labels, variables)
-
-    # Iteratively merge clusters that exceed the budget
-    changed = True
+    name_to_idx = {v.variable_name: i for i, v in enumerate(variables)}
     next_id = int(labels.max()) + 1
+
+    changed = True
     while changed:
         changed = False
-        sizes = {
-            cid: _cluster_token_count(vars_, approx_tokens_per_label)
-            for cid, vars_ in cluster_map.items()
-        }
-        for cid, tokens in sorted(sizes.items(), key=lambda x: -x[1]):
+        oversized = sorted(
+            (
+                (cid, _cluster_token_count(vars_, approx_tokens_per_label))
+                for cid, vars_ in cluster_map.items()
+            ),
+            key=lambda x: -x[1],
+        )
+        for cid, tokens in oversized:
             if tokens <= max_tokens_per_cluster:
                 continue
-            # Split: keep half, merge the other half into a new cluster
-            vars_list = cluster_map[cid]
-            half = len(vars_list) // 2
-            keep_vars = vars_list[:half]
-            new_vars = vars_list[half:]
-            # Find variable name -> index map
-            name_to_idx = {v.variable_name: i for i, v in enumerate(variables)}
-            # Reassign new_vars to next_id
-            for var in new_vars:
-                idx = name_to_idx.get(var.variable_name)
-                if idx is not None:
-                    labels[idx] = next_id
-            cluster_map[cid] = keep_vars
-            cluster_map[next_id] = new_vars
+
+            remaining = list(cluster_map[cid])
+            if len(remaining) <= 1:
+                # A single variable exceeds the budget; cannot split further.
+                continue
+
+            move_vars: List[DictionaryVariable] = []
+            while (
+                len(remaining) > 1
+                and _cluster_token_count(remaining, approx_tokens_per_label)
+                > max_tokens_per_cluster
+            ):
+                move_vars.insert(0, remaining.pop())
+
+            if not move_vars:
+                continue
+
+            for var in move_vars:
+                labels[name_to_idx[var.variable_name]] = next_id
+
+            cluster_map[cid] = remaining
+            cluster_map[next_id] = move_vars
             next_id += 1
             changed = True
             break  # restart loop after any change

--- a/src/ai4data/metadata/augmentation/clustering.py
+++ b/src/ai4data/metadata/augmentation/clustering.py
@@ -13,6 +13,7 @@ All sklearn/numpy imports are lazy to avoid import-time overhead.
 from __future__ import annotations
 
 import math
+import warnings
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from .schemas import DictionaryVariable
@@ -237,7 +238,7 @@ def _cluster_token_count(
     )
 
 
-def merge_clusters_for_token_budget(
+def split_clusters_for_token_budget(
     cluster_labels: "np.ndarray",
     variables: List[DictionaryVariable],
     *,
@@ -313,6 +314,28 @@ def merge_clusters_for_token_budget(
             break  # restart loop after any change
 
     return labels
+
+
+def merge_clusters_for_token_budget(
+    cluster_labels: "np.ndarray",
+    variables: List[DictionaryVariable],
+    *,
+    max_tokens_per_cluster: int = DEFAULT_MAX_CLUSTER_TOKENS,
+    approx_tokens_per_label: int = DEFAULT_APPROX_TOKENS_PER_LABEL,
+) -> "np.ndarray":
+    """Deprecated alias for :func:`split_clusters_for_token_budget`."""
+    warnings.warn(
+        "merge_clusters_for_token_budget is deprecated; "
+        "use split_clusters_for_token_budget instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return split_clusters_for_token_budget(
+        cluster_labels,
+        variables,
+        max_tokens_per_cluster=max_tokens_per_cluster,
+        approx_tokens_per_label=approx_tokens_per_label,
+    )
 
 
 # ----- Utility ----- #

--- a/src/ai4data/metadata/augmentation/prompts.py
+++ b/src/ai4data/metadata/augmentation/prompts.py
@@ -1,58 +1,111 @@
-"""Prompt templates and utilities for data dictionary theme generation.
+"""Prompt templates and utilities for data dictionary variable group curation.
 
 The prompts follow an elicitation design: the LLM is asked to produce
-structured JSON conforming to the ``ThemeGenerationResult`` schema, not
-free-form text. This reduces hallucination and makes outputs parseable.
+structured JSON conforming to the ``VariableGroupCurationResult`` schema, not
+free-form text. Deterministic DDI fields (``vgid``, ``group_type``, etc.)
+are assembled downstream by the framework.
 
 Design choices:
 - ``SYSTEM_PROMPT``: Establishes the assistant role and output constraints.
   Explicitly forbids inventing variable names outside the provided list.
 - ``USER_PROMPT_TEMPLATE``: Renders the cluster variable list with a numbered
   format so the LLM can reference variables by name easily.
-- JSON schema: Derived from ``ThemeGenerationResult.model_json_schema()`` for
-  strict type-safe validation at the API boundary.
+- JSON schema: Derived from ``VariableGroupCurationResult.model_json_schema()``
+  for strict type-safe validation at the API boundary.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List
+from typing import Dict, List
 
-from .schemas import DictionaryVariable, ThemeGenerationResult
-
-if TYPE_CHECKING:
-    pass
+from .schemas import DictionaryVariable, VariableGroupCurationResult
 
 
 # ----- Prompt templates ----- #
 
 SYSTEM_PROMPT = """\
-You are a data catalog specialist for social science and development datasets.
+You are an expert metadata curator for social science, development, and administrative datasets.
 
-GOAL:
-Given a list of survey or administrative variable names and labels from a single \
-thematic cluster, generate:
-1. A concise theme name (2–6 words, title case, no punctuation)
-2. A factual 1–2 sentence description grounded in the variable labels provided
-3. Up to 5 representative variable names from the INPUT list
+Your task is to create one useful DDI-style variable group from a set of candidate variables.
 
-CONSTRAINTS:
-- Theme name: 2–6 words, title case. Examples: "Household Asset Ownership", \
-"Child Health and Nutrition", "Agricultural Land Use".
-- Description: factual, 1–2 sentences. Do not speculate beyond the variable labels.
-- Example variables: select up to 5 variable names EXACTLY as they appear in the \
-INPUT list. Do not invent or paraphrase variable names.
-- Output ONLY valid JSON matching the provided schema. No markdown, comments, or \
-any text outside the JSON object.
+The input variables are candidate variables identified as semantically related. They may all belong to the final variable group, or only a coherent subset may belong. Your role is to curate a useful variable group for a statistical data catalog.
+
+OUTPUT SCHEMA:
+Return exactly one JSON object with this structure:
+
+{
+  "label": "string",
+  "universe": "string",
+  "notes": "string",
+  "txt": "string",
+  "definition": "string",
+  "variables": ["string"]
+}
+
+FIELD RULES:
+
+label:
+- A concise user-facing name for the variable group.
+- Use 2–6 words in Title Case.
+- Capture the shared concept or domain of the selected variables.
+- Do not mention "cluster" or the grouping method.
+
+universe:
+- Describe the population or unit of observation only if clearly inferable from the variable labels.
+- Examples: "Households", "Individuals", "Children under five", "Agricultural households".
+- If not clearly inferable, return an empty string.
+
+notes:
+- Use only for important curation notes, such as excluded candidate variables or ambiguity in group membership.
+- If variables are excluded, briefly state which ones and why.
+- If no notes are needed, return an empty string.
+
+txt:
+- One or two factual sentences describing the subject matter represented by the variable group.
+- Write like metadata in a statistical data catalog.
+- Explain what the selected variables collectively describe.
+- Prefer the common domain or construct over an exhaustive list of individual variables.
+- Do not speculate beyond the provided labels.
+- Do not refer to embeddings, clustering, or the grouping process.
+
+definition:
+- A brief rationale for the grouping.
+- Explain why the selected variables form a coherent variable group.
+- Ground the rationale in the shared subject matter of the selected variable labels.
+
+variables:
+- Include the variable identifiers that belong to the curated group.
+- Use variable names EXACTLY as they appear in the input.
+- Return them as a JSON array of strings.
+- Include all variables that fit the group.
+- Exclude variables that do not fit the common concept.
+- The group may include all input variables or only a coherent subset.
+
+CURATION RULES:
+- Prefer a coherent and interpretable variable group over maximizing coverage.
+- If all candidate variables fit the same concept, include all of them.
+- If the candidates contain multiple concepts, select the strongest coherent group and exclude weaker or unrelated variables.
+- Do not include variables merely because they share similar words.
+- Do not invent, modify, or paraphrase variable names.
+- Do not mention coding schemes, missing values, frequencies, or technical metadata unless central to the group.
+- Output ONLY valid JSON.
+- Do not output markdown, explanations, comments, or additional text.
 """
 
 USER_PROMPT_TEMPLATE = """\
 # TASK
-Generate a theme name and description for the following cluster of survey variables.
+
+Create one DDI-style variable group from the following candidate variables.
+
+The variables are candidates for a thematic variable group. They may all belong to the final group, or only a coherent subset may belong.
+
+Your task is to identify the most useful common subject matter, select the variables that belong to that group, and produce metadata using the required schema.
 
 # VARIABLES
+
 {variable_list}
 
-Output ONLY valid JSON matching the schema. Do not include markdown or extra text.\
+Return ONLY valid JSON matching the required schema.
 """
 
 
@@ -121,32 +174,30 @@ def render_user_prompt(variables: List[DictionaryVariable]) -> str:
     str
         Formatted user prompt string.
     """
-    return USER_PROMPT_TEMPLATE.format(
-        variable_list=render_variable_list(variables)
-    )
+    return USER_PROMPT_TEMPLATE.format(variable_list=render_variable_list(variables))
 
 
 # ----- Response format schema ----- #
 
 
-def get_theme_response_format() -> Dict:
-    """Return the JSON schema dict for structured theme generation responses.
+def get_variable_group_response_format() -> Dict:
+    """Return the JSON schema dict for structured variable group curation responses.
 
     This is passed as the ``response_format`` argument to litellm / OpenAI
-    structured output APIs. The schema is derived from ``ThemeGenerationResult``
-    using Pydantic's ``model_json_schema()``, ensuring that the LLM response
-    always matches the expected Python type.
+    structured output APIs. The schema is derived from
+    ``VariableGroupCurationResult`` using Pydantic's ``model_json_schema()``,
+    ensuring that the LLM response always matches the expected Python type.
 
     Returns
     -------
     dict
         ``{"type": "json_schema", "json_schema": {...}}`` format.
     """
-    schema = ThemeGenerationResult.model_json_schema()
+    schema = VariableGroupCurationResult.model_json_schema()
     return {
         "type": "json_schema",
         "json_schema": {
-            "name": "theme_generation",
+            "name": "variable_group_curation",
             "strict": True,
             "schema": schema,
         },
@@ -157,8 +208,8 @@ def get_json_object_format() -> Dict:
     """Return a basic JSON object response format for providers without strict schema support.
 
     Some litellm providers accept ``{"type": "json_object"}`` but not the full
-    JSON Schema format. Use this as a fallback when ``get_theme_response_format``
-    is not supported.
+    JSON Schema format. Use this as a fallback when
+    ``get_variable_group_response_format`` is not supported.
 
     Returns
     -------

--- a/src/ai4data/metadata/augmentation/qa.py
+++ b/src/ai4data/metadata/augmentation/qa.py
@@ -1,0 +1,117 @@
+"""Self-consistency QA prompts for variable group curation.
+
+After the curation LLM produces a proposed variable group (label, txt,
+definition, and selected variables), the QA agent assesses whether those
+parts are mutually coherent — the second stage of self-consistency prompting.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+from .prompts import render_variable_list
+from .schemas import (
+    DictionaryVariable,
+    VariableGroupCurationResult,
+    VariableGroupQAResult,
+)
+
+
+QA_SYSTEM_PROMPT = """\
+You are a metadata quality assurance reviewer for statistical data catalogs.
+
+Your task is to assess whether a proposed DDI-style variable group is
+self-consistent. A group is self-consistent when its label, description,
+grouping rationale, and selected variables all describe the same subject
+matter and support one another.
+
+OUTPUT SCHEMA:
+Return exactly one JSON object with this structure:
+
+{
+  "is_self_consistent": true,
+  "rationale": "string"
+}
+
+FIELD RULES:
+
+is_self_consistent:
+- Return true only if the label, txt, definition, and selected variables
+  are mutually coherent.
+- Return false if any part contradicts or is unsupported by the others.
+
+rationale:
+- Briefly explain your decision.
+- When is_self_consistent is false, state the specific inconsistency
+  (e.g., label claims health but variables are geographic identifiers).
+- When is_self_consistent is true, a short confirmation is sufficient.
+
+ASSESSMENT CRITERIA:
+- Does the label accurately summarize the shared subject of the selected
+  variables?
+- Does txt describe what the selected variables collectively measure or
+  represent, without overclaiming or referring to unrelated concepts?
+- Does definition provide a plausible rationale for grouping these
+  specific variables?
+- Do the selected variable labels support the stated label and description?
+- Ignore any candidate variables not included in the proposed group.
+
+Output ONLY valid JSON. Do not output markdown, explanations outside the
+JSON, comments, or additional text.
+"""
+
+QA_USER_PROMPT_TEMPLATE = """\
+# TASK
+
+Assess whether the following proposed variable group is self-consistent.
+
+Review the group metadata and the labels of the selected variables. Decide
+whether the label, txt, definition, and variables form a coherent group.
+
+# PROPOSED GROUP
+
+Label: {label}
+Universe: {universe}
+Notes: {notes}
+Description (txt): {txt}
+Definition: {definition}
+Selected variables: {variables_json}
+
+# SELECTED VARIABLE LABELS
+
+{variable_list}
+
+Return ONLY valid JSON matching the required schema.
+"""
+
+
+def render_qa_user_prompt(
+    cluster_variables: List[DictionaryVariable],
+    curation: VariableGroupCurationResult,
+) -> str:
+    """Render the QA user prompt for a proposed variable group."""
+    selected_names = set(curation.variables)
+    selected = [v for v in cluster_variables if v.variable_name in selected_names]
+    return QA_USER_PROMPT_TEMPLATE.format(
+        label=curation.label,
+        universe=curation.universe or "(empty)",
+        notes=curation.notes or "(empty)",
+        txt=curation.txt,
+        definition=curation.definition,
+        variables_json=json.dumps(curation.variables),
+        variable_list=render_variable_list(selected),
+    )
+
+
+def get_qa_response_format() -> Dict:
+    """Return the JSON schema dict for structured QA responses."""
+    schema = VariableGroupQAResult.model_json_schema()
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "variable_group_qa",
+            "strict": True,
+            "schema": schema,
+        },
+    }

--- a/src/ai4data/metadata/augmentation/schemas.py
+++ b/src/ai4data/metadata/augmentation/schemas.py
@@ -151,6 +151,13 @@ class VariableGroupCurationResult(StrictBaseModel):
         return result
 
 
+class VariableGroupQAResult(StrictBaseModel):
+    """LLM output from the self-consistency QA agent."""
+
+    is_self_consistent: bool
+    rationale: str = ""
+
+
 # ----- Output schema ----- #
 
 
@@ -167,6 +174,8 @@ class VariableGroup(StrictBaseModel):
     txt: str
     definition: str
     cluster_id: int
+    qa_passed: Optional[bool] = None
+    qa_rationale: str = ""
 
     @classmethod
     def from_curation(
@@ -174,8 +183,19 @@ class VariableGroup(StrictBaseModel):
         curation: VariableGroupCurationResult,
         *,
         cluster_id: int,
+        qa: Optional[VariableGroupQAResult] = None,
+        qa_error: Optional[str] = None,
     ) -> VariableGroup:
         """Build a full DDI variable group from validated LLM curation output."""
+        if qa is not None:
+            qa_passed = qa.is_self_consistent
+            qa_rationale = qa.rationale
+        elif qa_error is not None:
+            qa_passed = None
+            qa_rationale = qa_error
+        else:
+            qa_passed = None
+            qa_rationale = ""
         return cls(
             vgid=make_vgid(curation.label, cluster_id),
             variables=" ".join(curation.variables),
@@ -187,6 +207,8 @@ class VariableGroup(StrictBaseModel):
             txt=curation.txt,
             definition=curation.definition,
             cluster_id=cluster_id,
+            qa_passed=qa_passed,
+            qa_rationale=qa_rationale,
         )
 
     @classmethod

--- a/src/ai4data/metadata/augmentation/schemas.py
+++ b/src/ai4data/metadata/augmentation/schemas.py
@@ -64,10 +64,16 @@ class StrictBaseModel(BaseModel):
 
 def make_vgid(label: str, cluster_id: int) -> str:
     """Build a stable VG_* identifier from label slug and cluster_id."""
-    slug = re.sub(r"[^A-Za-z0-9]+", "_", label.upper()).strip("_")
-    slug = slug or "GROUP"
-    return f"VG_{slug}_{cluster_id:04d}"[:128]
+    prefix = "VG_"
+    suffix = f"_{cluster_id:04d}"
+    max_len = 128
+    max_slug_len = max_len - len(prefix) - len(suffix)
 
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", label.upper()).strip("_") or "GROUP"
+    if len(slug) > max_slug_len:
+        slug = slug[:max_slug_len].rstrip("_") or "GROUP"
+
+    return f"{prefix}{slug}{suffix}"
 
 def make_uncategorized_vgid(cluster_id: int) -> str:
     """Build a deterministic vgid for fallback uncategorized groups."""

--- a/src/ai4data/metadata/augmentation/schemas.py
+++ b/src/ai4data/metadata/augmentation/schemas.py
@@ -1,13 +1,53 @@
 """Pydantic schemas for data dictionary augmentation.
 
 This module defines the canonical data structures used throughout the
-metadata augmentation pipeline: loading variables, generating themes,
+metadata augmentation pipeline: loading variables, generating variable groups,
 and assembling the augmented dictionary output.
 """
 
-from typing import Annotated, Any, Dict, List, Optional
+from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+import json
+import re
+from typing import Annotated, Any, Dict, List, Literal, Optional, Set, Union
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# ----- DDI group types ----- #
+
+DDI_GROUP_TYPES = (
+    "section",
+    "multipleResp",
+    "grid",
+    "display",
+    "repetition",
+    "subject",
+    "version",
+    "iteration",
+    "analysis",
+    "pragmatic",
+    "record",
+    "file",
+    "randomized",
+    "other",
+)
+
+GroupType = Literal[
+    "section",
+    "multipleResp",
+    "grid",
+    "display",
+    "repetition",
+    "subject",
+    "version",
+    "iteration",
+    "analysis",
+    "pragmatic",
+    "record",
+    "file",
+    "randomized",
+    "other",
+]
 
 
 # ----- Base ----- #
@@ -17,6 +57,21 @@ class StrictBaseModel(BaseModel):
     """Base model with strict validation (no extra fields)."""
 
     model_config = ConfigDict(extra="forbid", strict=True)
+
+
+# ----- Helpers ----- #
+
+
+def make_vgid(label: str, cluster_id: int) -> str:
+    """Build a stable VG_* identifier from label slug and cluster_id."""
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", label.upper()).strip("_")
+    slug = slug or "GROUP"
+    return f"VG_{slug}_{cluster_id:04d}"[:128]
+
+
+def make_uncategorized_vgid(cluster_id: int) -> str:
+    """Build a deterministic vgid for fallback uncategorized groups."""
+    return f"VG_UNCATEGORIZED_{cluster_id:04d}"
 
 
 # ----- Input schema ----- #
@@ -47,92 +102,132 @@ class DictionaryVariable(StrictBaseModel):
 # ----- LLM response schema ----- #
 
 
-class ThemeGenerationResult(StrictBaseModel):
-    """Raw LLM output for a single cluster's theme.
+class VariableGroupCurationResult(StrictBaseModel):
+    """Raw LLM output for a single cluster's variable group curation.
 
-    This schema is used to validate the JSON response from the LLM at the
-    API boundary. It is then converted to a ``Theme`` in the augmented output.
-
-    Parameters
-    ----------
-    theme_name : str
-        2–6 word title-case theme name (e.g., "Household Asset Ownership").
-    description : str
-        1–2 sentence description grounded in the variable labels.
-    example_variables : list of str
-        Up to 5 variable names from the cluster that best represent the theme.
+    Only fields the LLM is expected to generate. Deterministic DDI fields
+    (``vgid``, ``variable_groups``, ``group_type``, formatted ``variables``)
+    are assembled by :class:`VariableGroup`.
     """
 
-    theme_name: str
-    description: str
-    example_variables: List[str]
+    label: str
+    universe: str = ""
+    notes: str = ""
+    txt: str
+    definition: str
+    variables: Annotated[List[str], Field(min_length=1)]
+
+    @model_validator(mode="after")
+    def _normalize_variables(self) -> VariableGroupCurationResult:
+        cleaned = [v.strip() for v in self.variables if v and v.strip()]
+        if not cleaned:
+            raise ValueError("variables must contain at least one non-empty name")
+        if len(cleaned) != len(set(cleaned)):
+            raise ValueError("variables must not contain duplicate names")
+        object.__setattr__(self, "variables", cleaned)
+        return self
+
+    @classmethod
+    def from_llm_response(
+        cls,
+        data: Union[str, dict],
+        *,
+        candidate_names: Set[str],
+    ) -> VariableGroupCurationResult:
+        """Parse and validate an LLM response against the candidate variable set."""
+        if isinstance(data, str):
+            parsed = json.loads(data)
+        else:
+            parsed = data
+
+        result = cls.model_validate(parsed)
+
+        unknown = [name for name in result.variables if name not in candidate_names]
+        if unknown:
+            raise ValueError(
+                f"variables not in candidate set: {', '.join(unknown)}"
+            )
+
+        return result
 
 
 # ----- Output schema ----- #
 
 
-class Theme(StrictBaseModel):
-    """A validated, LLM-generated thematic cluster.
+class VariableGroup(StrictBaseModel):
+    """A validated DDI-style variable group."""
 
-    Parameters
-    ----------
-    theme_name : str
-        2–6 word title-case theme name.
-    description : str
-        1–2 sentence description of the theme.
-    example_variables : list of str
-        1–5 representative variable names from this theme.
-    """
+    vgid: str
+    variables: str
+    variable_groups: str = ""
+    group_type: GroupType = "subject"
+    label: str
+    universe: str = ""
+    notes: str = ""
+    txt: str
+    definition: str
+    cluster_id: int
 
-    theme_name: str
-    description: str
-    example_variables: Annotated[
-        List[str],
-        Field(
-            min_length=1,
-            max_length=5,
-            description="Representative variable names from this theme.",
-        ),
-    ]
+    @classmethod
+    def from_curation(
+        cls,
+        curation: VariableGroupCurationResult,
+        *,
+        cluster_id: int,
+    ) -> VariableGroup:
+        """Build a full DDI variable group from validated LLM curation output."""
+        return cls(
+            vgid=make_vgid(curation.label, cluster_id),
+            variables=" ".join(curation.variables),
+            variable_groups="",
+            group_type="subject",
+            label=curation.label,
+            universe=curation.universe,
+            notes=curation.notes,
+            txt=curation.txt,
+            definition=curation.definition,
+            cluster_id=cluster_id,
+        )
+
+    @classmethod
+    def uncategorized_fallback(
+        cls,
+        *,
+        cluster_id: int,
+        variable_names: List[str],
+    ) -> VariableGroup:
+        """Build a fallback group when LLM curation fails."""
+        return cls(
+            vgid=make_uncategorized_vgid(cluster_id),
+            variables=" ".join(variable_names),
+            variable_groups="",
+            group_type="other",
+            label="Uncategorized",
+            universe="",
+            notes="",
+            txt="Variable group curation failed for this cluster.",
+            definition="Fallback group assigned when curation could not be completed.",
+            cluster_id=cluster_id,
+        )
 
 
-class ThemeAssignment(StrictBaseModel):
-    """Maps a single variable to its assigned theme and cluster.
-
-    Parameters
-    ----------
-    variable_name : str
-        The variable identifier.
-    theme_name : str
-        The name of the theme this variable was assigned to.
-    cluster_id : int
-        The numeric cluster ID from the clustering step.
-    """
+class VariableGroupAssignment(StrictBaseModel):
+    """Maps a curated variable to its variable group and source cluster."""
 
     variable_name: str
-    theme_name: str
+    vgid: str
+    label: str
     cluster_id: int
 
 
 class AugmentedDictionary(StrictBaseModel):
     """Top-level output of the augmentation pipeline.
 
-    Contains the generated themes and a full mapping of every variable to
-    its theme, along with optional run metadata (model, timestamp, config).
-
-    Parameters
-    ----------
-    dataset_id : str, optional
-        Identifier for the source dataset (e.g., NADA survey ID).
-    themes : list of Theme
-        All generated themes, one per cluster.
-    variable_assignments : list of ThemeAssignment
-        One entry per input variable, mapping it to a theme and cluster.
-    metadata : dict, optional
-        Run configuration: model name, embedding model, timestamp, etc.
+    Contains generated variable groups and assignments for curated variables,
+    along with optional run metadata (model, timestamp, config).
     """
 
     dataset_id: Optional[str] = None
-    themes: List[Theme]
-    variable_assignments: List[ThemeAssignment]
+    variable_groups: List[VariableGroup]
+    variable_assignments: List[VariableGroupAssignment]
     metadata: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary

Refactors the metadata augmentation pipeline from theme generation to **DDI-style variable group curation**, adds a **self-consistency QA agent**, improves cluster token-budget handling, and introduces **parallel per-cluster LLM generation** to reduce wall-clock time on large dictionaries.

## Changes

### DDI variable group curation
- LLM now returns `label`, `txt`, `definition`, and curated `variables` per cluster
- Framework sets deterministic fields (`vgid`, `group_type`, `variable_groups`)
- Curated variable names are validated against cluster candidates
- Removed the old 5-variable cap

### Self-consistency QA agent
- Optional second LLM pass checks that label, description, definition, and selected variables cohere
- Failures are flagged via `qa_passed=False` without discarding curation output
- QA stats recorded in run metadata (`n_qa_passed`, `n_qa_failed`, `n_qa_skipped`)
- Configurable via `enable_qa` and `qa_model` (defaults to `claude-sonnet-4-6`)

### Clustering and UX improvements
- Oversized clusters split by peeling trailing variables (instead of halving)
- Default cluster token budget raised to 2048
- Optional tqdm progress bar for variable group generation

### Parallel LLM generation
- New `max_concurrency` parameter (default `1` = sequential)
- Exposed on constructor, `generate_variable_groups()`, and `augment()`
- Uses `ThreadPoolExecutor`; curation → QA stays sequential within each cluster
- Run metadata includes `max_concurrency`

### Documentation
- Updated `docs/metadata-augmentation/` (index, methodology)
- Updated `docs/inclusive-ai/inclusive-ai.md` for default model references

## Test plan

- [ ] Run augmentation on a small dictionary with default settings (`max_concurrency=1`) and verify variable groups, assignments, and QA flags
- [ ] Re-run with `max_concurrency=5` and confirm all clusters are processed with correct QA counters
- [ ] Verify `augment(max_concurrency=N)` passes concurrency through correctly
- [ ] Confirm tqdm progress bar works in both sequential and parallel modes
- [ ] Export to JSON and inspect `AugmentedDictionary` schema fields (`vgid`, `qa_passed`, metadata)