### PR TITLE
feat(discovery): add metadata-extract catalog backend and TLS truststore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 	"fastapi>=0.135.1",
 	"uvicorn>=0.42.0",
 	"pexpect>=4.9.0",
+	"truststore>=0.10.4",
 ]
 [project.optional-dependencies]
 # Core data use extraction (dataset mention extraction from text/documents)
@@ -95,6 +96,7 @@ metadata = [
 # NADA discovery (catalog fetch, metadata templates, PDF helpers)
 discovery = [
   "httpx>=0.27.0",
+  "truststore>=0.10.4",
   "backoff>=2.2.1",
   "tqdm>=4.65.0",
   "pydantic>=2.0.0",

--- a/src/ai4data/__init__.py
+++ b/src/ai4data/__init__.py
@@ -20,14 +20,9 @@ For all capabilities:
 
 from importlib.metadata import version, PackageNotFoundError
 
-# Use the OS trust store for TLS: corporate proxies re-sign API traffic
-# with CAs that certifi doesn't know.
-try:
-    import truststore
+from .discovery.ssl import configure_tls_trust_store
 
-    truststore.inject_into_ssl()
-except ImportError:
-    pass
+configure_tls_trust_store()
 
 try:
     __version__ = version("ai4data")

--- a/src/ai4data/__init__.py
+++ b/src/ai4data/__init__.py
@@ -17,7 +17,17 @@ This package provides various AI-powered tools for data analysis:
 For all capabilities:
   uv pip install ai4data[all]
 """
+
 from importlib.metadata import version, PackageNotFoundError
+
+# Use the OS trust store for TLS: corporate proxies re-sign API traffic
+# with CAs that certifi doesn't know.
+try:
+    import truststore
+
+    truststore.inject_into_ssl()
+except ImportError:
+    pass
 
 try:
     __version__ = version("ai4data")

--- a/src/ai4data/discovery/README.md
+++ b/src/ai4data/discovery/README.md
@@ -68,6 +68,16 @@ Defined in [`config.py`](./config.py) (`DiscoveryDataConfig`). Used by [`paths.p
 
 **Precedence:** `init_discovery_paths(Path("..."))` with a non-`None` path always wins over the env var. Calling `init_discovery_paths(None)` (or `init_discovery_paths()` with default) applies `_default_data_root()`, which respects `AI4DATA_DISCOVERY_DATA_PATH` when set.
 
+### TLS / corporate proxy (`truststore`, `SSL_CERT_FILE`)
+
+Catalog HTTP clients call :func:`ai4data.discovery.ssl.configure_tls_trust_store` on import. With the **`discovery`** extra installed, **`truststore`** injects the **OS trust store** into Python's :mod:`ssl` module so :mod:`httpx` can verify TLS through corporate proxies that re-sign traffic (CAs in macOS Keychain, Windows cert store, etc.).
+
+| Situation | What to do |
+|-----------|------------|
+| **Host ingest on macOS** | Install `ai4data[discovery]` (includes `truststore`); ingest should work if the site opens in your browser |
+| **Docker ingest** | The container only has Debian public CAs — **not** your Mac Keychain. Export your org root CA to a `.pem` file and set `SSL_CERT_FILE` (see nada-ai `docs/qdrant-pipeline-guide.md`, TLS section) |
+| **Custom CA file (any env)** | Set `SSL_CERT_FILE` or `REQUESTS_CA_BUNDLE` to a `.pem` bundle before running ingest |
+
 ### Optional: Apache Tika
 
 [`processors/document.py`](./processors/document.py) uses **`tika`** for `tika_parse_pdf`. The Python package may require a running Tika server or local JAR; see [tika-python](https://github.com/chrismattmann/tika-python) documentation for server/JVM setup. That is runtime configuration outside `ai4data.discovery.config`.

--- a/src/ai4data/discovery/README.md
+++ b/src/ai4data/discovery/README.md
@@ -20,6 +20,12 @@ Defined in [`config.py`](./config.py) (`MetadataCatalogConfig`). Used by [`catal
 | `AI4DATA_METADATA_CATALOG_THUMBNAIL_URL` | No | Format string for document thumbnails; must include `{db_id}` (default matches NADA public thumbnails). |
 | `AI4DATA_METADATA_CATALOG_X_API_KEY` | Only for authenticated APIs | API key sent as header `x-api-key`. Used by [`catalog/data_api.py`](./catalog/data_api.py), and — when set — also attached by [`catalog/http.py`](./catalog/http.py) (search, JSON metadata) and [`metadata/document_fetch.py`](./metadata/document_fetch.py) (PDF downloads). For PDF downloads the header is only sent when the URL's host matches the configured catalog host (or is allow-listed via `AI4DATA_METADATA_CATALOG_X_API_KEY_HOSTS`), so the credential is never sent to third-party hosts embedded as external resources. |
 | `AI4DATA_METADATA_CATALOG_X_API_KEY_HOSTS` | No | Comma-separated list of additional hostnames allowed to receive `x-api-key` for catalog-resolved downloads (e.g. `training.ihsn.org`). The catalog host itself is always allowed; use this when downloads are served from a separate subdomain. |
+| `AI4DATA_METADATA_CATALOG_COOKIES` | No | Optional cookie string for authenticated catalog / PDF download sessions. |
+| `AI4DATA_METADATA_CATALOG_EXTRACT_PATH` | No | When set (e.g. `api/admin/search-metadata-extract`), list and fetch metadata via the bulk extract API at `{URL}/{EXTRACT_PATH}/studies` instead of catalog search + per-idno JSON. Omit to keep classic behavior. |
+| `AI4DATA_METADATA_CATALOG_EXTRACT_INCLUDE_ADMIN_METADATA` | No | Query flag for extract requests (default: `true`). |
+| `AI4DATA_METADATA_CATALOG_EXTRACT_INCLUDE_METADATA` | No | Include full NADA JSON in extract responses (default: `true`; required for ingest). |
+| `AI4DATA_METADATA_CATALOG_EXTRACT_FALLBACK_CATALOG_JSON` | No | When `true`, `get_metadata_json(..., include_resources=True)` may fall back to `/api/catalog/json/{idno}` if resources are missing from extract payloads (default: `false`). |
+| `AI4DATA_METADATA_CATALOG_AUTH_BEARER` | No | Optional bearer token for admin extract endpoints. |
 
 ### Embedding templates (`AI4DATA_EMBEDDING_*`)
 

--- a/src/ai4data/discovery/__init__.py
+++ b/src/ai4data/discovery/__init__.py
@@ -3,3 +3,7 @@
 Filesystem layout for discovery caches and id lists: :mod:`ai4data.discovery.paths`.
 Catalog API URLs and embedding-template root: :mod:`ai4data.discovery.config`.
 """
+
+from .ssl import configure_tls_trust_store
+
+configure_tls_trust_store()

--- a/src/ai4data/discovery/catalog/README.md
+++ b/src/ai4data/discovery/catalog/README.md
@@ -7,7 +7,7 @@ Public surface for **NADA** metadata: HTTP client, batch jobs, and ids used by d
 | Module | Role |
 |--------|------|
 | `http.py` | Catalog HTTP API: `get_metadata_json`, `search_metadata`, `get_ids_type`, `get_metadata_ids`. Routes to extract API when `AI4DATA_METADATA_CATALOG_EXTRACT_PATH` is set. |
-| `extract.py` | IHSN search-metadata-extract client: paginated `/studies`, `study_to_catalog_metadata`, param mapping. |
+| `extract.py` | IHSN search-metadata-extract client: paginated `/studies`, `study_to_catalog_metadata`, param mapping. Study-level `resources` with `_links.type == "download"` are normalized to catalog `external_resources`. |
 | `batch.py` | Save id lists, `scrape_all_ids`, `scrape_all_metadata`, Fire `main`. Run: `python -m ai4data.discovery.catalog.batch`. |
 | `data_api.py` | Authenticated JSON GET (`x-api-key`) for separate IHSN/API resources. |
 | `langdoc_id.py` | `get_langdoc_uuid` and UUID helper for chunk ids. |
@@ -16,6 +16,20 @@ Public surface for **NADA** metadata: HTTP client, batch jobs, and ids used by d
 ## Related (not in `discovery/catalog/`)
 
 - **PDF download/cache** for document metadata: `ai4data.discovery.metadata.document_fetch` (`cache_download_pdf`, `download_pdf`).
+
+### Extract resources and PDF cache naming
+
+When extract mode is enabled, each study may include a top-level `resources` array. Only entries with `_links.type == "download"` are kept (external `"link"` mirrors are ignored). They are mapped to `external_resources` with:
+
+- `url` ← `_links.download` (NADA admin download URL)
+- `resource_id` preserved from the extract payload
+
+Document PDFs are cached under `document_cache/document/` as:
+
+- **Extract mode:** `document_{idno}--{resource_id}.pdf` (double hyphen separates idno from resource id because idno contains underscores)
+- **Classic catalog:** `document_{idno}.pdf` (unchanged)
+
+Re-index with `--force` or delete old PDFs after switching naming conventions.
 
 ## Legacy shims
 

--- a/src/ai4data/discovery/catalog/README.md
+++ b/src/ai4data/discovery/catalog/README.md
@@ -6,7 +6,8 @@ Public surface for **NADA** metadata: HTTP client, batch jobs, and ids used by d
 
 | Module | Role |
 |--------|------|
-| `http.py` | Catalog HTTP API: `get_metadata_json`, `search_metadata`, `get_ids_type`, `get_metadata_ids`. |
+| `http.py` | Catalog HTTP API: `get_metadata_json`, `search_metadata`, `get_ids_type`, `get_metadata_ids`. Routes to extract API when `AI4DATA_METADATA_CATALOG_EXTRACT_PATH` is set. |
+| `extract.py` | IHSN search-metadata-extract client: paginated `/studies`, `study_to_catalog_metadata`, param mapping. |
 | `batch.py` | Save id lists, `scrape_all_ids`, `scrape_all_metadata`, Fire `main`. Run: `python -m ai4data.discovery.catalog.batch`. |
 | `data_api.py` | Authenticated JSON GET (`x-api-key`) for separate IHSN/API resources. |
 | `langdoc_id.py` | `get_langdoc_uuid` and UUID helper for chunk ids. |

--- a/src/ai4data/discovery/catalog/__init__.py
+++ b/src/ai4data/discovery/catalog/__init__.py
@@ -15,13 +15,16 @@ packages (e.g. ``nada-opensearch``).
 
 from __future__ import annotations
 
-from .http import get_ids_type, get_metadata_ids, get_metadata_json, search_metadata
+from . import extract as catalog_extract
+from .http import get_ids_type, get_metadata_ids, get_metadata_json, is_extract_mode, search_metadata
 from .langdoc_id import get_langdoc_uuid
 
 __all__ = [
+    "catalog_extract",
     "get_metadata_json",
     "get_metadata_ids",
     "get_ids_type",
     "search_metadata",
     "get_langdoc_uuid",
+    "is_extract_mode",
 ]

--- a/src/ai4data/discovery/catalog/batch.py
+++ b/src/ai4data/discovery/catalog/batch.py
@@ -12,8 +12,9 @@ from collections.abc import Callable
 from fire import Fire
 from tqdm.auto import tqdm
 
-from ..paths import get_metadata_ids_path
-from .http import get_metadata_ids, get_metadata_json, search_metadata
+from ..paths import get_metadata_cache_path, get_metadata_ids_path
+from . import extract as catalog_extract
+from .http import get_metadata_ids, get_metadata_json, is_extract_mode, search_metadata
 
 
 def save_metadata_ids(metadata_ids: list, dtype: str) -> None:
@@ -34,6 +35,25 @@ def save_metadata_ids(metadata_ids: list, dtype: str) -> None:
         json.dump(metadata_ids, f, indent=2)
 
 
+def _normalize_scrape_params(params: dict) -> tuple[dict, str]:
+    params = dict(params)
+    assert "ps" in params, "The number of items per page is required"
+    assert "type" in params, "The type of metadata is required, e.g., timeseries, document, geospatial, etc."
+
+    if params["type"] == "indicator":
+        params["type"] = "timeseries"
+    if params["type"] == "microdata":
+        params["type"] = "survey"
+
+    dtype = params["type"]
+    if dtype == "timeseries":
+        dtype = "indicator"
+    elif dtype == "survey":
+        dtype = "microdata"
+
+    return params, dtype
+
+
 def scrape_all_ids(
     get_metadata_ids_func: Callable = get_metadata_ids,
     search_metadata_func: Callable = search_metadata,
@@ -49,25 +69,51 @@ def scrape_all_ids(
         save_metadata_ids_func (Callable, optional): Function or task to save metadata IDs.
         **kwargs: Arbitrary keyword arguments representing search parameters.
     """
-    params = kwargs
-
-    assert "ps" in params, "The number of items per page is required"
-    assert "type" in params, "The type of metadata is required, e.g., timeseries, document, geospatial, etc."
-
-    if params["type"] == "indicator":
-        params["type"] = "timeseries"
-    if params["type"] == "microdata":
-        params["type"] = "survey"
-
-    dtype = params["type"]
-    if dtype == "timeseries":
-        dtype = "indicator"
-    elif dtype == "survey":
-        dtype = "microdata"
+    params, dtype = _normalize_scrape_params(kwargs)
 
     metadata_ids = get_metadata_ids_func(params, search_metadata_func=search_metadata_func)
     print(f"Total metadata ids: {len(metadata_ids)}")
 
+    save_metadata_ids_func(metadata_ids, dtype)
+
+
+def _scrape_all_metadata_extract(
+    params: dict,
+    dtype: str,
+    *,
+    force: bool = False,
+    skip_errors: bool = False,
+    save_metadata_ids_func: Callable = save_metadata_ids,
+) -> None:
+    """Single-pass extract scrape: paginate studies, cache metadata, save id list."""
+    metadata_ids: list[dict] = []
+
+    for study in tqdm(catalog_extract.iter_extract_studies(params)):
+        try:
+            metadata = catalog_extract.study_to_catalog_metadata(study)
+            idno = metadata.get("idno") or catalog_extract.study_idno(study)
+            metadata_type = metadata.get("type")
+            if not idno or not metadata_type:
+                continue
+
+            if force or not get_metadata_cache_path(idno, metadata_type).exists():
+                catalog_extract.write_metadata_cache(metadata, idno, metadata_type)
+
+            row = catalog_extract.study_to_search_row(study)
+            metadata_ids.append(
+                {
+                    "id": row.get("id"),
+                    "idno": idno,
+                    "type": metadata_type,
+                }
+            )
+        except Exception as e:
+            idno = catalog_extract.study_idno(study) or "unknown"
+            print(f"Error processing metadata for {idno}: {e}")
+            if not skip_errors:
+                raise
+
+    print(f"Total metadata ids: {len(metadata_ids)}")
     save_metadata_ids_func(metadata_ids, dtype)
 
 
@@ -90,6 +136,18 @@ def scrape_all_metadata(
     """
 
     skip_errors = kwargs.get("skip_errors", False)
+    force = kwargs.get("force", False)
+
+    if is_extract_mode():
+        params, dtype = _normalize_scrape_params(kwargs)
+        _scrape_all_metadata_extract(
+            params,
+            dtype,
+            force=force,
+            skip_errors=skip_errors,
+            save_metadata_ids_func=save_metadata_ids_func,
+        )
+        return
 
     scrape_all_ids(
         get_metadata_ids_func=get_metadata_ids_func,
@@ -99,8 +157,6 @@ def scrape_all_metadata(
     )
 
     dtype = kwargs.get("type", "timeseries")
-    force = kwargs.get("force", False)
-
     if dtype == "indicator":
         dtype = "timeseries"
 

--- a/src/ai4data/discovery/catalog/extract.py
+++ b/src/ai4data/discovery/catalog/extract.py
@@ -12,7 +12,10 @@ import httpx
 from ..auth import get_catalog_auth_headers, get_catalog_cookies
 from ..config import METADATA_CATALOG_URL, metadata_catalog
 from ..paths import get_metadata_cache_path
+from ..ssl import configure_tls_trust_store
 from ..type_normalization import normalize_catalog_metadata_type
+
+configure_tls_trust_store()
 
 SUCCESS_STATUSES = {"", "success", "ok"}
 

--- a/src/ai4data/discovery/catalog/extract.py
+++ b/src/ai4data/discovery/catalog/extract.py
@@ -140,6 +140,37 @@ def study_metadata_type(study: dict[str, Any]) -> str | None:
     return None
 
 
+def study_download_resources(study: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize extract study resources with ``_links.type == \"download\"`` to catalog shape."""
+    raw = study.get("resources")
+    if not isinstance(raw, list):
+        return []
+
+    downloads: list[dict[str, Any]] = []
+    for resource in raw:
+        if not isinstance(resource, dict):
+            continue
+        links = resource.get("_links")
+        if not isinstance(links, dict) or links.get("type") != "download":
+            continue
+        url = links.get("download")
+        if not url:
+            continue
+
+        item: dict[str, Any] = {
+            "resource_id": resource.get("resource_id"),
+            "url": url,
+            "dcformat": resource.get("dcformat"),
+            "is_url": str(resource.get("is_url", "0")),
+        }
+        for key in ("title", "dctype", "resource_type", "filename", "sort_order"):
+            if resource.get(key) is not None:
+                item[key] = resource[key]
+        downloads.append(item)
+
+    return downloads
+
+
 def study_to_search_row(study: dict[str, Any]) -> dict[str, Any]:
     """Build a catalog-search-compatible row from one extract study payload."""
     core = study.get("core_fields") if isinstance(study.get("core_fields"), dict) else {}
@@ -169,6 +200,10 @@ def study_to_catalog_metadata(study: dict[str, Any]) -> dict[str, Any]:
     filters = study.get("filters")
     if isinstance(filters, dict):
         result["_extract_filters"] = filters
+
+    downloads = study_download_resources(study)
+    if downloads:
+        result["external_resources"] = downloads
 
     return result
 

--- a/src/ai4data/discovery/catalog/extract.py
+++ b/src/ai4data/discovery/catalog/extract.py
@@ -1,0 +1,372 @@
+"""IHSN search-metadata-extract API client (bulk studies list + single study fetch)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ..auth import get_catalog_auth_headers, get_catalog_cookies
+from ..config import METADATA_CATALOG_URL, metadata_catalog
+from ..paths import get_metadata_cache_path
+from ..type_normalization import normalize_catalog_metadata_type
+
+SUCCESS_STATUSES = {"", "success", "ok"}
+
+
+class CatalogExtractError(RuntimeError):
+    """Raised when the metadata-extract API returns an error payload."""
+
+
+def extract_base_url() -> str | None:
+    """Return the extract API base URL, or ``None`` when extract mode is disabled."""
+    path = metadata_catalog.extract_path
+    if not path:
+        return None
+    return f"{metadata_catalog.url.rstrip('/')}/{path.strip('/')}"
+
+
+def is_extract_mode() -> bool:
+    return extract_base_url() is not None
+
+
+def _get_extract_auth_headers() -> dict[str, str]:
+    headers = dict(get_catalog_auth_headers())
+    bearer = metadata_catalog.auth_bearer
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    return headers
+
+
+def _extract_query_flags(
+    *,
+    include_admin_metadata: bool | None = None,
+    include_metadata: bool | None = None,
+) -> dict[str, str]:
+    admin = (
+        metadata_catalog.extract_include_admin_metadata
+        if include_admin_metadata is None
+        else include_admin_metadata
+    )
+    meta = (
+        metadata_catalog.extract_include_metadata
+        if include_metadata is None
+        else include_metadata
+    )
+    return {
+        "include_admin_metadata": "1" if admin else "0",
+        "include_metadata": "1" if meta else "0",
+    }
+
+
+def _parse_extract_response(data: dict[str, Any]) -> None:
+    status = str(data.get("status") or "").lower()
+    if status not in SUCCESS_STATUSES:
+        message = data.get("message") or data.get("error") or status
+        raise CatalogExtractError(f"API error ({status}): {message}")
+
+
+def _request_extract(
+    url: str,
+    params: dict[str, Any] | None = None,
+    *,
+    headers: dict[str, str] | None = None,
+    cookies: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    response = httpx.get(
+        url,
+        params=params,
+        headers=headers if headers is not None else _get_extract_auth_headers(),
+        cookies=cookies if cookies is not None else get_catalog_cookies(),
+        timeout=120.0,
+    )
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise CatalogExtractError(f"Expected JSON object from {url}, got {type(data).__name__}")
+    _parse_extract_response(data)
+    return data
+
+
+def map_catalog_params_to_extract(params: dict[str, Any] | None) -> dict[str, Any]:
+    """Map classic ``/api/catalog/search`` params to extract ``/studies`` query params."""
+    params = dict(params or {})
+    out: dict[str, Any] = {}
+
+    ps = int(params.get("ps", 100))
+    page = int(params.get("page", 1))
+    out["limit"] = ps
+    out["offset"] = (page - 1) * ps
+
+    if catalog_type := params.get("type"):
+        out["type"] = catalog_type
+
+    for key in ("source", "sk", "sort_by", "sort_order"):
+        if key in params and params[key] not in (None, ""):
+            out[key] = params[key]
+
+    return out
+
+
+def study_idno(study: dict[str, Any]) -> str | None:
+    core = study.get("core_fields")
+    if isinstance(core, dict):
+        idno = core.get("idno")
+        if idno:
+            return str(idno).strip()
+    idno = study.get("idno")
+    return str(idno).strip() if idno else None
+
+
+def study_metadata_type(study: dict[str, Any]) -> str | None:
+    metadata = study.get("metadata")
+    if isinstance(metadata, dict):
+        mtype = metadata.get("type")
+        if mtype:
+            return normalize_catalog_metadata_type(str(mtype))
+
+    filters = study.get("filters")
+    if isinstance(filters, dict):
+        dataset_type = filters.get("dataset_type")
+        if dataset_type:
+            return normalize_catalog_metadata_type(str(dataset_type))
+
+    return None
+
+
+def study_to_search_row(study: dict[str, Any]) -> dict[str, Any]:
+    """Build a catalog-search-compatible row from one extract study payload."""
+    core = study.get("core_fields") if isinstance(study.get("core_fields"), dict) else {}
+    return {
+        "id": core.get("id") or study.get("id"),
+        "idno": study_idno(study),
+        "type": study_metadata_type(study),
+    }
+
+
+def study_to_catalog_metadata(study: dict[str, Any]) -> dict[str, Any]:
+    """Normalize an extract study payload to the shape returned by ``/api/catalog/json/{idno}``."""
+    metadata = study.get("metadata")
+    if not isinstance(metadata, dict):
+        raise CatalogExtractError("Study missing metadata payload (set include_metadata=1)")
+
+    result = dict(metadata)
+
+    idno = study_idno(study)
+    if idno:
+        result["idno"] = idno
+
+    mtype = result.get("type") or study_metadata_type(study)
+    if mtype:
+        result["type"] = normalize_catalog_metadata_type(str(mtype))
+
+    filters = study.get("filters")
+    if isinstance(filters, dict):
+        result["_extract_filters"] = filters
+
+    return result
+
+
+def _studies_from_response(data: dict[str, Any]) -> list[dict[str, Any]]:
+    studies = data.get("studies")
+    if isinstance(studies, list):
+        return [s for s in studies if isinstance(s, dict)]
+
+    study = data.get("study")
+    if isinstance(study, dict):
+        return [study]
+
+    if "metadata" in data or "filters" in data:
+        return [data]
+
+    return []
+
+
+def fetch_extract_page(
+    params: dict[str, Any] | None = None,
+    *,
+    include_admin_metadata: bool | None = None,
+    include_metadata: bool | None = None,
+    base_url: str | None = None,
+    headers: dict[str, str] | None = None,
+    cookies: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Fetch one paginated ``/studies`` page."""
+    base = base_url or extract_base_url()
+    if not base:
+        raise CatalogExtractError("Extract path is not configured")
+
+    query = {**_extract_query_flags(
+        include_admin_metadata=include_admin_metadata,
+        include_metadata=include_metadata,
+    )}
+    if params:
+        query.update(params)
+
+    return _request_extract(
+        f"{base.rstrip('/')}/studies",
+        params=query,
+        headers=headers,
+        cookies=cookies,
+    )
+
+
+def fetch_extract_study(
+    idno: str,
+    *,
+    include_admin_metadata: bool | None = None,
+    include_metadata: bool | None = None,
+    base_url: str | None = None,
+    headers: dict[str, str] | None = None,
+    cookies: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Fetch a single study by idno."""
+    base = base_url or extract_base_url()
+    if not base:
+        raise CatalogExtractError("Extract path is not configured")
+
+    query = _extract_query_flags(
+        include_admin_metadata=include_admin_metadata,
+        include_metadata=include_metadata,
+    )
+    encoded = quote(idno.strip(), safe="")
+    return _request_extract(
+        f"{base.rstrip('/')}/studies/{encoded}",
+        params=query,
+        headers=headers,
+        cookies=cookies,
+    )
+
+
+def search_metadata_extract(
+    params: dict[str, Any] | None = None,
+    *,
+    base_url: str | None = None,
+    headers: dict[str, str] | None = None,
+    cookies: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Return catalog-search-compatible ``{rows, found}`` from one extract page."""
+    extract_params = map_catalog_params_to_extract(params)
+    data = fetch_extract_page(
+        extract_params,
+        base_url=base_url,
+        headers=headers,
+        cookies=cookies,
+    )
+    rows = [study_to_search_row(study) for study in _studies_from_response(data)]
+    total = data.get("total")
+    found = int(total) if isinstance(total, int) else len(rows)
+    return {"rows": rows, "found": found}
+
+
+def iter_extract_studies(
+    params: dict[str, Any] | None = None,
+    *,
+    max_items: int | None = None,
+    include_admin_metadata: bool | None = None,
+    include_metadata: bool | None = None,
+    base_url: str | None = None,
+    headers: dict[str, str] | None = None,
+    cookies: dict[str, str] | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Paginate all studies matching ``params`` (classic search param shape)."""
+    base_params = dict(params or {})
+    page_size = int(base_params.pop("ps", 100))
+    base_params.pop("page", None)
+
+    offset = 0
+    seen = 0
+
+    while True:
+        page_params = map_catalog_params_to_extract({**base_params, "ps": page_size, "page": 1})
+        page_params["offset"] = offset
+        page_params["limit"] = page_size
+
+        data = fetch_extract_page(
+            page_params,
+            include_admin_metadata=include_admin_metadata,
+            include_metadata=include_metadata,
+            base_url=base_url,
+            headers=headers,
+            cookies=cookies,
+        )
+        batch = _studies_from_response(data)
+        if not batch:
+            break
+
+        for study in batch:
+            yield study
+            seen += 1
+            if max_items is not None and seen >= max_items:
+                return
+
+        if not data.get("has_more"):
+            break
+        offset += page_size
+
+
+def write_metadata_cache(
+    metadata: dict[str, Any],
+    idno: str,
+    metadata_type: str,
+    *,
+    include_resources: bool = False,
+) -> None:
+    cache_path = get_metadata_cache_path(idno, metadata_type, include_resources=include_resources)
+    try:
+        with cache_path.open("w") as cache_file:
+            json.dump(metadata, cache_file, indent=2)
+    except OSError as e:
+        print(f"Failed to write cache file {cache_path}: {e}")
+
+
+def _metadata_has_resources(metadata: dict[str, Any]) -> bool:
+    for key in ("resources", "external_resources", "microdata_resources"):
+        value = metadata.get(key)
+        if isinstance(value, list) and value:
+            return True
+    return False
+
+
+def fetch_metadata_from_extract(
+    idno: str,
+    metadata_type: str | None = None,
+    *,
+    include_resources: bool = False,
+) -> dict[str, Any]:
+    """Fetch and normalize metadata for one idno from the extract API."""
+    data = fetch_extract_study(idno)
+    studies = _studies_from_response(data)
+    if not studies:
+        raise CatalogExtractError(f"No study found for idno {idno!r}")
+
+    metadata = study_to_catalog_metadata(studies[0])
+
+    if metadata_type and metadata.get("type") != metadata_type:
+        raise ValueError(
+            f"The metadata type {metadata.get('type')} does not match the requested type: {metadata_type}"
+        )
+
+    if (
+        include_resources
+        and not _metadata_has_resources(metadata)
+        and metadata_catalog.extract_fallback_catalog_json
+    ):
+        response = httpx.get(
+            f"{METADATA_CATALOG_URL}/api/catalog/json/{idno}",
+            params={"include_resources": True},
+            headers=get_catalog_auth_headers(),
+            cookies=get_catalog_cookies(),
+        )
+        response.raise_for_status()
+        fallback: dict = response.json()
+        if fallback.get("type") == "timeseries":
+            fallback["type"] = "indicator"
+        if fallback.get("type") == "survey":
+            fallback["type"] = "microdata"
+        metadata = fallback
+
+    return metadata

--- a/src/ai4data/discovery/catalog/http.py
+++ b/src/ai4data/discovery/catalog/http.py
@@ -18,7 +18,10 @@ from tqdm.auto import tqdm
 from ..auth import get_catalog_auth_headers, get_catalog_cookies
 from ..config import METADATA_CATALOG_URL
 from ..paths import get_metadata_cache_path
+from ..ssl import configure_tls_trust_store
 from . import extract as catalog_extract
+
+configure_tls_trust_store()
 
 
 def is_extract_mode() -> bool:

--- a/src/ai4data/discovery/catalog/http.py
+++ b/src/ai4data/discovery/catalog/http.py
@@ -3,6 +3,9 @@ HTTP client for the NADA metadata catalog (search + JSON by idno).
 
 Canonical implementation; ``ai4data.scraper.metadata`` re-exports batch helpers from
 :mod:`ai4data.discovery.catalog.batch` and these functions for backward compatibility.
+
+When :envvar:`AI4DATA_METADATA_CATALOG_EXTRACT_PATH` is set, list/fetch operations use
+the search-metadata-extract ``/studies`` API instead of catalog search + per-idno JSON.
 """
 
 from __future__ import annotations
@@ -15,6 +18,11 @@ from tqdm.auto import tqdm
 from ..auth import get_catalog_auth_headers, get_catalog_cookies
 from ..config import METADATA_CATALOG_URL
 from ..paths import get_metadata_cache_path
+from . import extract as catalog_extract
+
+
+def is_extract_mode() -> bool:
+    return catalog_extract.is_extract_mode()
 
 
 def get_metadata_json(
@@ -54,31 +62,39 @@ def get_metadata_json(
             print(f"Failed to read cache file {cache_path}: {e}")
 
     try:
-        # Add query parameters to the request
-        params = {
-            "include_resources": include_resources,
-        }
-        response = httpx.get(
-            f"{METADATA_CATALOG_URL}/api/catalog/json/{idno}",
-            params=params,
-            headers=get_catalog_auth_headers(),
-            cookies=get_catalog_cookies(),
-        )
-        response.raise_for_status()
-        metadata: dict = response.json()
+        if is_extract_mode():
+            metadata = catalog_extract.fetch_metadata_from_extract(
+                idno,
+                metadata_type,
+                include_resources=include_resources,
+            )
+        else:
+            params = {
+                "include_resources": include_resources,
+            }
+            response = httpx.get(
+                f"{METADATA_CATALOG_URL}/api/catalog/json/{idno}",
+                params=params,
+                headers=get_catalog_auth_headers(),
+                cookies=get_catalog_cookies(),
+            )
+            response.raise_for_status()
+            metadata: dict = response.json()
 
-        if metadata.get("type", None) == "timeseries":
-            metadata["type"] = "indicator"
-        if metadata.get("type", None) == "survey":
-            metadata["type"] = "microdata"
+            if metadata.get("type", None) == "timeseries":
+                metadata["type"] = "indicator"
+            if metadata.get("type", None) == "survey":
+                metadata["type"] = "microdata"
 
-        if metadata_type:
-            if metadata_type and metadata.get("type", None) != metadata_type:
-                raise ValueError(
-                    f"The metadata type {metadata.get('type')} does not match the requested type: {metadata_type}"
-                )
+            if metadata_type:
+                if metadata_type and metadata.get("type", None) != metadata_type:
+                    raise ValueError(
+                        f"The metadata type {metadata.get('type')} does not match the requested type: {metadata_type}"
+                    )
 
     except httpx.HTTPStatusError as e:
+        raise RuntimeError(f"Failed to fetch metadata for ID {idno}: {e}") from e
+    except catalog_extract.CatalogExtractError as e:
         raise RuntimeError(f"Failed to fetch metadata for ID {idno}: {e}") from e
 
     if cache_path:
@@ -93,6 +109,9 @@ def get_metadata_json(
 
 def search_metadata(params: dict = None) -> dict:
     """Search metadata in the metadata catalog using provided search parameters."""
+    if is_extract_mode():
+        return catalog_extract.search_metadata_extract(params)
+
     response = httpx.get(
         f"{METADATA_CATALOG_URL}/api/catalog/search",
         params=params,
@@ -124,12 +143,17 @@ def get_metadata_ids(
     params: dict = None,
     search_metadata_func=search_metadata,
     max_items: int | None = None,
+    cache_metadata: bool = False,
+    include_resources: bool = False,
 ) -> list:
     """
     Retrieve metadata IDs from the metadata catalog based on search parameters.
 
     Paginates through every page unless ``max_items`` is set, in which case pagination
     stops once that many rows have been collected (fewer HTTP calls for smoke tests).
+
+    When extract mode is enabled and ``cache_metadata`` is true, full metadata JSON is
+    written to the discovery cache during the list pass (avoids N+1 fetches downstream).
     """
     default_params = dict(
         sk="", ps=100, type="timeseries", sort_by="year", sort_order="asc"
@@ -138,6 +162,13 @@ def get_metadata_ids(
 
     if max_items is not None and max_items <= 0:
         return []
+
+    if is_extract_mode() and cache_metadata:
+        return _get_metadata_ids_extract_cached(
+            params,
+            max_items=max_items,
+            include_resources=include_resources,
+        )
 
     all_metadata_ids: list = []
 
@@ -159,3 +190,35 @@ def get_metadata_ids(
             return all_metadata_ids[:max_items]
 
     return all_metadata_ids if max_items is None else all_metadata_ids[:max_items]
+
+
+def _get_metadata_ids_extract_cached(
+    params: dict,
+    *,
+    max_items: int | None,
+    include_resources: bool,
+) -> list:
+    all_metadata_ids: list = []
+
+    for study in catalog_extract.iter_extract_studies(params, max_items=max_items):
+        try:
+            metadata = catalog_extract.study_to_catalog_metadata(study)
+        except catalog_extract.CatalogExtractError as e:
+            print(f"Skip study without metadata: {e}")
+            continue
+
+        idno = metadata.get("idno") or catalog_extract.study_idno(study)
+        metadata_type = metadata.get("type")
+        if not idno or not metadata_type:
+            continue
+
+        catalog_extract.write_metadata_cache(
+            metadata,
+            idno,
+            metadata_type,
+            include_resources=include_resources,
+        )
+        row = catalog_extract.study_to_search_row(study)
+        all_metadata_ids.append(get_ids_type(row))
+
+    return all_metadata_ids

--- a/src/ai4data/discovery/config.py
+++ b/src/ai4data/discovery/config.py
@@ -39,6 +39,31 @@ class MetadataCatalogConfig(BaseSettings):
             "URLs (catalog host plus ``x_api_key_hosts``)."
         ),
     )
+    extract_path: str | None = Field(
+        default=None,
+        description=(
+            "Optional path segment for the IHSN search-metadata-extract API "
+            "(e.g. ``api/admin/search-metadata-extract``). When set, catalog list/fetch "
+            "operations use ``{url}/{extract_path}/studies`` instead of "
+            "``/api/catalog/search`` + ``/api/catalog/json/{idno}``."
+        ),
+    )
+    extract_include_admin_metadata: bool = Field(default=True)
+    extract_include_metadata: bool = Field(default=True)
+    extract_fallback_catalog_json: bool = Field(
+        default=False,
+        description=(
+            "When true and ``include_resources`` is requested, fall back to the classic "
+            "``/api/catalog/json/{idno}`` endpoint if the extract payload lacks resources."
+        ),
+    )
+    auth_bearer: str | None = Field(
+        default=None,
+        description=(
+            "Optional bearer token sent as ``Authorization: Bearer ...`` on extract API "
+            "requests (admin endpoints that do not accept ``x-api-key`` alone)."
+        ),
+    )
 
 
 class EmbeddingTemplatesConfig(BaseSettings):

--- a/src/ai4data/discovery/metadata/document_fetch.py
+++ b/src/ai4data/discovery/metadata/document_fetch.py
@@ -72,7 +72,13 @@ def download_pdf(url: str) -> bytes:
     return content
 
 
-def cache_download_pdf(url: str, idno: str, metadata_type: str, force: bool = False):
+def cache_download_pdf(
+    url: str,
+    idno: str,
+    metadata_type: str,
+    force: bool = False,
+    resource_id: str | None = None,
+):
     """
     Cache the downloaded pdf file.
 
@@ -81,7 +87,7 @@ def cache_download_pdf(url: str, idno: str, metadata_type: str, force: bool = Fa
     don't permanently poison the cache.
     """
 
-    fpath = get_document_cache_path(idno, metadata_type)
+    fpath = get_document_cache_path(idno, metadata_type, resource_id=resource_id)
 
     if fpath.exists() and not force:
         try:

--- a/src/ai4data/discovery/metadata/document_fetch.py
+++ b/src/ai4data/discovery/metadata/document_fetch.py
@@ -11,6 +11,9 @@ import httpx
 
 from ..auth import get_catalog_auth_headers, get_catalog_cookies
 from ..paths import get_document_cache_path
+from ..ssl import configure_tls_trust_store
+
+configure_tls_trust_store()
 
 logger = logging.getLogger(__name__)
 

--- a/src/ai4data/discovery/metadata/handler.py
+++ b/src/ai4data/discovery/metadata/handler.py
@@ -228,6 +228,39 @@ class IndicatorMetadata(Metadata):
         return langdocs
 
 
+def _is_pdf_dcformat(dcformat: object) -> bool:
+    if not dcformat:
+        return False
+    normalized = str(dcformat).strip().lower()
+    return normalized in ("application/pdf", "pdf")
+
+
+def _pdf_download_candidates(metadata: dict) -> list[dict]:
+    """Return hosted PDF external resources, or a legacy single URL fallback."""
+    external_resources = metadata.get("external_resources")
+    if isinstance(external_resources, list) and external_resources:
+        candidates: list[dict] = []
+        for resource in external_resources:
+            if not isinstance(resource, dict):
+                continue
+            is_url = str(resource.get("is_url", "1"))
+            if is_url not in ("0", "1"):
+                raise AssertionError(
+                    f'Invalid `is_url` value: {is_url}, expected "0" or "1"'
+                )
+            if _is_pdf_dcformat(resource.get("dcformat")) and is_url == "0":
+                url = resource.get("url")
+                if url:
+                    candidates.append(resource)
+        if candidates:
+            return candidates
+
+    legacy_url = metadata.get("document_description", {}).get("url")
+    if legacy_url:
+        return [{"url": legacy_url}]
+    return []
+
+
 class DocumentMetadata(Metadata):
     """
     Ideas for how we should work with documents:
@@ -274,42 +307,27 @@ class DocumentMetadata(Metadata):
         Returns:
             list: A list of LangChain documents.
         """
+        idno = self.metadata.get("idno")
+        langdocs: list[LangchainDocument] = []
 
-        # Check if the document url is in the metadata
-        url = self.metadata.get("document_description", {}).get("url", None)
-
-        # If external resources are available, prefer that over the document url
-        external_resources = self.metadata.get("external_resources", None)
-        if external_resources:
-            for resource in external_resources:
-                is_url = str(resource.get("is_url", "1"))
-                assert is_url in ("0", "1"), (
-                    f'Invalid `is_url` value: {is_url}, expected "0" or "1"'
-                )
-                if (
-                    resource.get("dcformat", None) == "application/pdf"
-                    and is_url == "0"
-                ):
-                    url = resource.get("url", None)
-                    # We only consider the first pdf url we find
-                    # TODO: We should consider all pdf urls and use them all for the document
-                    break
-
-        docs = []
-
-        if url:
-            # Download the document pdf.
-            # We only consider pdfs for now.
-            pdf_path = cache_download_pdf(url, self.metadata.get("idno"), self.type)
-            docs = load_pdf(pdf_path)
-
-        return [
-            LangchainDocument(
-                page_content=doc.page_content,
-                metadata={"qfield": field, "doc_meta": doc.metadata, **self.payload},
+        for resource in _pdf_download_candidates(self.metadata):
+            url = resource["url"]
+            resource_id = resource.get("resource_id")
+            pdf_path = cache_download_pdf(
+                url,
+                idno,
+                self.type,
+                resource_id=str(resource_id) if resource_id is not None else None,
             )
-            for doc in docs
-        ]
+            for doc in load_pdf(pdf_path):
+                extra_meta: dict = {"qfield": field, "doc_meta": doc.metadata, **self.payload}
+                if resource_id is not None:
+                    extra_meta["resource_id"] = str(resource_id)
+                langdocs.append(
+                    LangchainDocument(page_content=doc.page_content, metadata=extra_meta)
+                )
+
+        return langdocs
 
     def get_langdocs(self) -> list[LangchainDocument]:
         """

--- a/src/ai4data/discovery/paths.py
+++ b/src/ai4data/discovery/paths.py
@@ -86,10 +86,14 @@ def get_metadata_cache_path(
         )
 
 
-def get_document_cache_path(idno: str, metadata_type: str) -> Path:
-    return construct_path(
-        DOCUMENT_CACHE_DIR / metadata_type, f"{metadata_type}_{idno}.pdf"
-    )
+def get_document_cache_path(
+    idno: str, metadata_type: str, resource_id: str | None = None
+) -> Path:
+    if resource_id is not None:
+        filename = f"{metadata_type}_{idno}--{resource_id}.pdf"
+    else:
+        filename = f"{metadata_type}_{idno}.pdf"
+    return construct_path(DOCUMENT_CACHE_DIR / metadata_type, filename)
 
 
 def get_contextualized_dimensions_path(idno: str, raw: bool = False) -> Path:

--- a/src/ai4data/discovery/ssl.py
+++ b/src/ai4data/discovery/ssl.py
@@ -1,0 +1,23 @@
+"""TLS trust store setup for discovery HTTP clients (catalog, extract, PDF fetch).
+
+Uses :mod:`truststore` when installed so Python/httpx pick up the OS trust store
+(e.g. macOS Keychain with corporate proxy CAs). Idempotent — safe to call multiple times.
+"""
+
+from __future__ import annotations
+
+_tls_configured = False
+
+
+def configure_tls_trust_store() -> None:
+    """Inject OS trust store into :mod:`ssl` (no-op if ``truststore`` is not installed)."""
+    global _tls_configured
+    if _tls_configured:
+        return
+    try:
+        import truststore
+
+        truststore.inject_into_ssl()
+    except ImportError:
+        pass
+    _tls_configured = True

--- a/tests/fixtures/extract_study_with_metadata.json
+++ b/tests/fixtures/extract_study_with_metadata.json
@@ -1,0 +1,39 @@
+{
+  "status": "success",
+  "offset": 0,
+  "limit": 1,
+  "total": 901,
+  "has_more": false,
+  "studies": [
+    {
+      "core_fields": {
+        "id": 42,
+        "idno": "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1"
+      },
+      "filters": {
+        "doctype": 1,
+        "published": 1,
+        "dataset_type": "document",
+        "year_start": 2025,
+        "year_end": 2025,
+        "countries": [181],
+        "regions": [7, 9],
+        "tags": []
+      },
+      "metadata": {
+        "type": "document",
+        "idno": "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1",
+        "metadata_information": {
+          "title": "Consumer Price Index May 2025",
+          "idno": "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1"
+        },
+        "document_description": {
+          "title_statement": {
+            "title": "Consumer Price Index May 2025"
+          },
+          "abstract": "Monthly CPI report."
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/extract_study_with_metadata.json
+++ b/tests/fixtures/extract_study_with_metadata.json
@@ -33,7 +33,48 @@
           },
           "abstract": "Monthly CPI report."
         }
-      }
+      },
+      "resources": [
+        {
+          "resource_id": "1",
+          "dctype": "Document, Other [doc/oth]",
+          "resource_type": "doc/oth",
+          "filename": "http://statistics.gov.rw/sites/default/files/documents/2025-06/CPI Publication _French_Mai 2025_0.pdf",
+          "is_url": "1",
+          "dcformat": "PDF",
+          "title": "INDICE DES PRIX A LA CONSOMMATION (IPC) MAI 2025",
+          "_links": {
+            "download": "http://statistics.gov.rw/sites/default/files/documents/2025-06/CPI Publication _French_Mai 2025_0.pdf",
+            "type": "link"
+          }
+        },
+        {
+          "resource_id": "772",
+          "dctype": "Document, Other [doc/oth]",
+          "resource_type": "doc/oth",
+          "filename": "CPI Publication _French_Mai 2025_0.pdf",
+          "is_url": "0",
+          "dcformat": "application/pdf",
+          "title": "INDICE DES PRIX A LA CONSOMMATION (IPC) MAI 2025",
+          "_links": {
+            "download": "https://training.ihsn.org/index.php/api/admin/resources/RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1/resources/download/772",
+            "type": "download"
+          }
+        },
+        {
+          "resource_id": "37",
+          "dctype": "Document, Analytical [doc/anl]",
+          "resource_type": "doc/anl",
+          "filename": "http://statistics.gov.rw/sites/default/files/documents/2025-06/CPI Publication _French_Mai 2025_0.pdf",
+          "is_url": "1",
+          "dcformat": "PDF",
+          "title": "INDICE DES PRIX A LA CONSOMMATION (IPC) MAI 2025",
+          "_links": {
+            "download": "http://statistics.gov.rw/sites/default/files/documents/2025-06/CPI Publication _French_Mai 2025_0.pdf",
+            "type": "link"
+          }
+        }
+      ]
     }
   ]
 }

--- a/tests/test_catalog_extract.py
+++ b/tests/test_catalog_extract.py
@@ -78,6 +78,30 @@ class TestStudyNormalization(unittest.TestCase):
         metadata = catalog_extract.study_to_catalog_metadata(study)
         self.assertEqual(metadata["type"], "indicator")
 
+    def test_study_download_resources_filters_link_type(self):
+        metadata = catalog_extract.study_to_catalog_metadata(SAMPLE_STUDY)
+        resources = metadata.get("external_resources", [])
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["resource_id"], "772")
+        self.assertEqual(
+            resources[0]["url"],
+            "https://training.ihsn.org/index.php/api/admin/resources/"
+            "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1/resources/download/772",
+        )
+        self.assertEqual(resources[0]["is_url"], "0")
+        self.assertEqual(resources[0]["dcformat"], "application/pdf")
+
+    def test_study_download_resources_empty_when_no_download_type(self):
+        study = dict(SAMPLE_STUDY)
+        study["resources"] = [
+            {
+                "resource_id": "1",
+                "_links": {"download": "http://example.test/doc.pdf", "type": "link"},
+            }
+        ]
+        metadata = catalog_extract.study_to_catalog_metadata(study)
+        self.assertNotIn("external_resources", metadata)
+
 
 class TestExtractHttp(ExtractModeTestCase):
     @mock.patch("ai4data.discovery.catalog.extract.httpx.get")

--- a/tests/test_catalog_extract.py
+++ b/tests/test_catalog_extract.py
@@ -1,0 +1,210 @@
+"""Tests for search-metadata-extract catalog backend."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from ai4data.discovery import paths as discovery_paths
+from ai4data.discovery.catalog import extract as catalog_extract
+from ai4data.discovery.catalog import http as catalog_http
+from ai4data.discovery.config import metadata_catalog
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+EXTRACT_LIST = json.loads((FIXTURES / "extract_study_with_metadata.json").read_text())
+SAMPLE_STUDY = EXTRACT_LIST["studies"][0]
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class ExtractModeTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        discovery_paths.init_discovery_paths(Path(self._tmpdir.name))
+
+        self._extract_patch = mock.patch.object(
+            metadata_catalog,
+            "extract_path",
+            "api/admin/search-metadata-extract",
+        )
+        self._extract_patch.start()
+        self.addCleanup(self._extract_patch.stop)
+
+        self.assertTrue(catalog_extract.is_extract_mode())
+
+
+class TestStudyNormalization(unittest.TestCase):
+    def test_study_to_catalog_metadata_document(self):
+        metadata = catalog_extract.study_to_catalog_metadata(SAMPLE_STUDY)
+        self.assertEqual(metadata["type"], "document")
+        self.assertEqual(metadata["idno"], "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1")
+        self.assertIn("_extract_filters", metadata)
+        self.assertEqual(metadata["_extract_filters"]["dataset_type"], "document")
+
+    def test_study_to_search_row(self):
+        row = catalog_extract.study_to_search_row(SAMPLE_STUDY)
+        self.assertEqual(row["idno"], "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1")
+        self.assertEqual(row["type"], "document")
+        self.assertEqual(row["id"], 42)
+
+    def test_map_catalog_params_to_extract(self):
+        mapped = catalog_extract.map_catalog_params_to_extract(
+            {"ps": 50, "page": 3, "type": "document", "source": "nada"}
+        )
+        self.assertEqual(mapped["limit"], 50)
+        self.assertEqual(mapped["offset"], 100)
+        self.assertEqual(mapped["type"], "document")
+        self.assertEqual(mapped["source"], "nada")
+
+    def test_type_alias_timeseries(self):
+        study = {
+            "core_fields": {"idno": "IND-1"},
+            "metadata": {"type": "timeseries", "idno": "IND-1"},
+        }
+        metadata = catalog_extract.study_to_catalog_metadata(study)
+        self.assertEqual(metadata["type"], "indicator")
+
+
+class TestExtractHttp(ExtractModeTestCase):
+    @mock.patch("ai4data.discovery.catalog.extract.httpx.get")
+    def test_search_metadata_extract_shape(self, mock_get):
+        mock_get.return_value = _FakeResponse(EXTRACT_LIST)
+
+        data = catalog_http.search_metadata({"ps": 1, "page": 1, "type": "document"})
+
+        self.assertEqual(len(data["rows"]), 1)
+        self.assertEqual(data["found"], 901)
+        self.assertEqual(data["rows"][0]["idno"], "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1")
+
+    @mock.patch("ai4data.discovery.catalog.extract.httpx.get")
+    def test_get_metadata_json_extract_writes_cache(self, mock_get):
+        single = {"status": "success", "study": SAMPLE_STUDY}
+        mock_get.return_value = _FakeResponse(single)
+
+        metadata = catalog_http.get_metadata_json(
+            "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1",
+            "document",
+            force=True,
+        )
+
+        self.assertEqual(metadata["type"], "document")
+        cache_path = discovery_paths.get_metadata_cache_path(
+            "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1",
+            "document",
+        )
+        self.assertTrue(cache_path.exists())
+
+    @mock.patch("ai4data.discovery.catalog.extract.httpx.get")
+    def test_get_metadata_ids_cache_metadata(self, mock_get):
+        mock_get.return_value = _FakeResponse(EXTRACT_LIST)
+
+        rows = catalog_http.get_metadata_ids(
+            {"ps": 100, "type": "document"},
+            cache_metadata=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        cache_path = discovery_paths.get_metadata_cache_path(
+            "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1",
+            "document",
+        )
+        self.assertTrue(cache_path.exists())
+
+    @mock.patch("ai4data.discovery.catalog.extract.httpx.get")
+    def test_access_denied_raises(self, mock_get):
+        mock_get.return_value = _FakeResponse({"status": "ACCESS-DENIED"})
+
+        with self.assertRaises(catalog_extract.CatalogExtractError):
+            catalog_extract.fetch_extract_page({"offset": 0, "limit": 1})
+
+
+class TestClassicCatalogRegression(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        discovery_paths.init_discovery_paths(Path(self._tmpdir.name))
+
+    def test_extract_mode_disabled_by_default(self):
+        with mock.patch.object(metadata_catalog, "extract_path", None):
+            self.assertFalse(catalog_extract.is_extract_mode())
+
+    @mock.patch("ai4data.discovery.catalog.http.httpx.get")
+    def test_search_metadata_uses_catalog_search(self, mock_get):
+        with mock.patch.object(metadata_catalog, "extract_path", None):
+            mock_get.return_value = _FakeResponse(
+                {"result": {"rows": [{"idno": "X", "type": "document"}], "found": 1}}
+            )
+
+            data = catalog_http.search_metadata({"ps": 10, "page": 1})
+
+            self.assertEqual(len(data["rows"]), 1)
+            called_url = mock_get.call_args.args[0]
+            self.assertIn("/api/catalog/search", called_url)
+
+    @mock.patch("ai4data.discovery.catalog.http.httpx.get")
+    def test_get_metadata_json_uses_catalog_json(self, mock_get):
+        with mock.patch.object(metadata_catalog, "extract_path", None):
+            mock_get.return_value = _FakeResponse({"type": "document", "idno": "DOC-1"})
+
+            metadata = catalog_http.get_metadata_json("DOC-1", "document", force=True)
+
+            self.assertEqual(metadata["idno"], "DOC-1")
+            called_url = mock_get.call_args.args[0]
+            self.assertIn("/api/catalog/json/DOC-1", called_url)
+
+
+class TestBatchExtractSinglePass(ExtractModeTestCase):
+    @mock.patch("ai4data.discovery.catalog.extract.httpx.get")
+    def test_scrape_all_metadata_single_http_sequence(self, mock_get):
+        from ai4data.discovery.catalog import batch as catalog_batch
+
+        page_one = dict(EXTRACT_LIST)
+        page_one["has_more"] = True
+        page_one["total"] = 2
+        page_two = {
+            "status": "success",
+            "offset": 1,
+            "limit": 1,
+            "total": 2,
+            "has_more": False,
+            "studies": [
+                {
+                    "core_fields": {"idno": "DOC-SECOND"},
+                    "filters": {"dataset_type": "document"},
+                    "metadata": {
+                        "type": "document",
+                        "idno": "DOC-SECOND",
+                        "metadata_information": {"title": "Second"},
+                    },
+                }
+            ],
+        }
+        mock_get.side_effect = [
+            _FakeResponse(page_one),
+            _FakeResponse(page_two),
+        ]
+
+        catalog_batch.scrape_all_metadata(type="document", ps=1, force=True)
+
+        self.assertEqual(mock_get.call_count, 2)
+        ids_path = discovery_paths.get_metadata_ids_path("document")
+        saved = json.loads(ids_path.read_text())
+        self.assertEqual(len(saved), 2)
+
+        for idno in ("RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1", "DOC-SECOND"):
+            cache_path = discovery_paths.get_metadata_cache_path(idno, "document")
+            self.assertTrue(cache_path.exists())

--- a/tests/test_discovery_document_fetch.py
+++ b/tests/test_discovery_document_fetch.py
@@ -140,6 +140,30 @@ class TestCacheDownloadPdf(_DocumentFetchTestCase):
         fpath = discovery_paths.get_document_cache_path("IDN-AUTH", "document")
         self.assertFalse(fpath.exists())
 
+    def test_resource_id_uses_double_hyphen_filename(self) -> None:
+        idno = "RWA_NISR_DOC_2025_CPI-MR_MAY_FR_V1"
+        resource_id = "772"
+        expected = discovery_paths.get_document_cache_path(
+            idno, "document", resource_id=resource_id
+        )
+        self.assertEqual(
+            expected.name,
+            f"document_{idno}--{resource_id}.pdf",
+        )
+
+        with mock.patch.object(
+            document_fetch.httpx, "get", return_value=_FakeResponse(_MIN_PDF)
+        ):
+            fpath = document_fetch.cache_download_pdf(
+                "https://example.test/doc.pdf",
+                idno,
+                "document",
+                resource_id=resource_id,
+            )
+
+        self.assertEqual(fpath, expected)
+        self.assertTrue(fpath.exists())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds an optional **metadata-extract** catalog backend (`AI4DATA_METADATA_CATALOG_EXTRACT_PATH`) so list/fetch can use `search-metadata-extract/studies` instead of classic catalog search + per-idno JSON, with single-pass batch scrape to avoid N+1 fetches during bulk ingest.
- Wires **study-level download resources** from the extract API into document indexing: keeps only `_links.type == download`, maps them to `external_resources`, and caches PDFs as `document_{idno}--{resource_id}.pdf`.
- Uses **truststore** for catalog HTTP and PDF fetch paths so TLS works on corporate networks with custom CAs.

## What's new

### Extract catalog backend
- New `src/ai4data/discovery/catalog/extract.py` client for paginated `/studies` list and single-study fetch.
- `MetadataCatalogConfig` gains `extract_path`, `extract_include_*`, `extract_fallback_catalog_json`, and `auth_bearer`.
- Batch scrape and cache warming updated to use extract mode when configured.

### Document indexing
- `handler.py` iterates all hosted PDF `external_resources` (not just the first).
- `document_fetch.py` / `paths.py` accept optional `resource_id` for cache path resolution.

### TLS
- New `ssl.py` injects OS trust store before httpx calls in catalog, extract, and document fetch.

## Files changed

| Area | Files |
|------|-------|
| Extract catalog | `catalog/extract.py`, `catalog/batch.py`, `catalog/http.py`, `config.py` |
| Documents / cache | `metadata/handler.py`, `metadata/document_fetch.py`, `paths.py` |
| TLS | `ssl.py`, `pyproject.toml` |
| Tests / docs | `tests/test_catalog_extract.py`, `tests/fixtures/extract_study_with_metadata.json`, README updates |

## How to test

- [ ] With `AI4DATA_METADATA_CATALOG_EXTRACT_PATH` unset, confirm classic catalog search + per-idno JSON still works.
- [ ] With extract path set (e.g. `api/admin/search-metadata-extract`), run batch catalog scrape and verify metadata cache is populated in one pass.
- [ ] Confirm only `_links.type == download` resources are indexed; link-type resources are excluded.
- [ ] Ingest a document study and verify PDFs cache as `document_{idno}--{resource_id}.pdf`.
- [ ] On a corporate network (or with a custom CA), confirm catalog and PDF fetch succeed without manual cert wiring.
- [ ] Run `pytest tests/test_catalog_extract.py tests/test_discovery_document_fetch.py`.

## Deployment note

New optional env vars (all under `AI4DATA_METADATA_CATALOG_*`):

| Variable | Default | Purpose |
|----------|---------|---------|
| `AI4DATA_METADATA_CATALOG_EXTRACT_PATH` | unset | Enable extract mode (e.g. `api/admin/search-metadata-extract`) |
| `AI4DATA_METADATA_CATALOG_AUTH_BEARER` | unset | Bearer token for admin extract endpoints |
| `AI4DATA_METADATA_CATALOG_EXTRACT_FALLBACK_CATALOG_JSON` | `false` | Fall back to classic JSON when extract payload lacks resources |

Adds `truststore>=0.10.4` to the discovery extra. Consumers should reinstall `ai4data[discovery]`.